### PR TITLE
Implement file node modifier stack

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,9 +10,9 @@ bl_info = {
 }
 
 import importlib
-from . import tree, sockets, nodes, operators, ui, menu, menu
+from . import tree, sockets, nodes, operators, ui, menu, modifiers
 
-modules = [tree, sockets, nodes, operators, ui, menu]
+modules = [tree, sockets, nodes, operators, ui, menu, modifiers]
 
 def register():
     for m in modules:

--- a/modifiers.py
+++ b/modifiers.py
@@ -1,0 +1,30 @@
+import bpy
+from bpy.types import PropertyGroup
+from bpy.props import PointerProperty, CollectionProperty, BoolProperty, IntProperty, StringProperty
+from .tree import FileNodesTree
+
+class FileNodeModItem(PropertyGroup):
+    name: StringProperty(name="Name")
+    node_tree: PointerProperty(type=FileNodesTree)
+    enabled: BoolProperty(name="Enabled", default=True)
+    stack_index: IntProperty(name="Index", default=0)
+
+class FileRoot(PropertyGroup):
+    file_node_modifiers: CollectionProperty(type=FileNodeModItem)
+    active_index: IntProperty(name="Active Modifier", default=-1)
+
+def _get_file(self):
+    scn = self.scene
+    return getattr(scn, 'File', None)
+
+def register():
+    bpy.utils.register_class(FileNodeModItem)
+    bpy.utils.register_class(FileRoot)
+    bpy.types.Scene.File = PointerProperty(type=FileRoot)
+    bpy.types.Context.File = property(_get_file)
+
+def unregister():
+    del bpy.types.Context.File
+    del bpy.types.Scene.File
+    bpy.utils.unregister_class(FileRoot)
+    bpy.utils.unregister_class(FileNodeModItem)

--- a/ui.py
+++ b/ui.py
@@ -1,8 +1,68 @@
 
 import bpy
-from bpy.types import Panel
+from bpy.types import Panel, UIList, Operator
+from .modifiers import FileNodeModItem
 from .tree import FileNodesTree
 
+
+class FILE_NODES_UL_modifiers(UIList):
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
+        row = layout.row(align=True)
+        row.prop(item, "enabled", text="")
+        if item.node_tree:
+            row.prop(item.node_tree, "name", text="", emboss=False)
+        else:
+            row.label(text="<None>")
+
+
+class FN_OT_mod_add(Operator):
+    bl_idname = "file_nodes.mod_add"
+    bl_label = "Add File Node Modifier"
+
+    def execute(self, context):
+        file = context.scene.File
+        item = file.file_node_modifiers.add()
+        item.node_tree = bpy.data.node_groups.new("File Nodes", 'FileNodesTreeType')
+        item.node_tree.use_fake_user = True
+        item.name = item.node_tree.name
+        item.stack_index = len(file.file_node_modifiers) - 1
+        file.active_index = item.stack_index
+        return {'FINISHED'}
+
+
+class FN_OT_mod_remove(Operator):
+    bl_idname = "file_nodes.mod_remove"
+    bl_label = "Remove File Node Modifier"
+
+    def execute(self, context):
+        file = context.scene.File
+        idx = file.active_index
+        if 0 <= idx < len(file.file_node_modifiers):
+            file.file_node_modifiers.remove(idx)
+            file.active_index = min(idx, len(file.file_node_modifiers) - 1)
+            for i, it in enumerate(file.file_node_modifiers):
+                it.stack_index = i
+        return {'FINISHED'}
+
+
+class FN_OT_mod_move(Operator):
+    bl_idname = "file_nodes.mod_move"
+    bl_label = "Move Modifier"
+
+    direction: bpy.props.EnumProperty(items=[('UP', 'Up', ''), ('DOWN', 'Down', '')])
+
+    def execute(self, context):
+        file = context.scene.File
+        idx = file.active_index
+        if self.direction == 'UP' and idx > 0:
+            file.file_node_modifiers.move(idx, idx - 1)
+            file.active_index -= 1
+        elif self.direction == 'DOWN' and idx < len(file.file_node_modifiers) - 1:
+            file.file_node_modifiers.move(idx, idx + 1)
+            file.active_index += 1
+        for i, it in enumerate(file.file_node_modifiers):
+            it.stack_index = i
+        return {'FINISHED'}
 class FILE_NODES_PT_global(Panel):
     bl_label = "File Nodes"
     bl_space_type = 'PROPERTIES'
@@ -11,17 +71,29 @@ class FILE_NODES_PT_global(Panel):
 
     def draw(self, context):
         layout = self.layout
-        col = layout.column()
-        trees = [nt for nt in bpy.data.node_groups if isinstance(nt, FileNodesTree)]
-        trees.sort(key=lambda t: t.fn_stack_index)
-        for t in trees:
-            row = col.row(align=True)
-            row.prop(t, 'fn_enabled', text='')
-            row.label(text=t.name)
-            row.prop(t, 'fn_stack_index', text='')
+        file = context.scene.File
+        row = layout.row()
+        row.template_list("FILE_NODES_UL_modifiers", "", file, "file_node_modifiers", file, "active_index")
+        col = row.column(align=True)
+        col.operator('file_nodes.mod_add', text="", icon='ADD')
+        col.operator('file_nodes.mod_remove', text="", icon='REMOVE')
+        col.separator()
+        col.operator('file_nodes.mod_move', text="", icon='TRIA_UP').direction = 'UP'
+        col.operator('file_nodes.mod_move', text="", icon='TRIA_DOWN').direction = 'DOWN'
+
         layout.operator('file_nodes.evaluate', icon='FILE_REFRESH')
 
+classes = (
+    FILE_NODES_UL_modifiers,
+    FN_OT_mod_add,
+    FN_OT_mod_remove,
+    FN_OT_mod_move,
+    FILE_NODES_PT_global,
+)
+
 def register():
-    bpy.utils.register_class(FILE_NODES_PT_global)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 def unregister():
-    bpy.utils.unregister_class(FILE_NODES_PT_global)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)


### PR DESCRIPTION
## Summary
- add FileNodeModItem and FileRoot property groups
- manage modifier stack in new UI list panel with add/remove/move operators
- keep new FileNodesTree instances alive using fake user
- evaluate enabled node trees from context.File

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68582fc3221c833089e0e7da61e72107