### PR TITLE
Implement File Node modifier stack

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,9 +10,9 @@ bl_info = {
 }
 
 import importlib
-from . import tree, sockets, nodes, operators, ui, menu, menu
+from . import tree, sockets, nodes, operators, ui, menu, modifiers
 
-modules = [tree, sockets, nodes, operators, ui, menu]
+modules = [tree, sockets, nodes, operators, ui, menu, modifiers]
 
 def register():
     for m in modules:

--- a/modifiers.py
+++ b/modifiers.py
@@ -1,0 +1,81 @@
+import bpy
+from bpy.types import PropertyGroup, UIList, Operator
+from .tree import FileNodesTree
+
+class FileNodeModItem(PropertyGroup):
+    node_tree: bpy.props.PointerProperty(type=FileNodesTree)
+    enabled: bpy.props.BoolProperty(name="Enabled", default=True)
+    name: bpy.props.StringProperty(name="Name", default="")
+    stack_index: bpy.props.IntProperty(name="Stack Index", default=0, min=0)
+
+class FILE_NODES_UL_modifiers(UIList):
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
+        if self.layout_type in {'DEFAULT', 'COMPACT'}:
+            row = layout.row(align=True)
+            row.prop(item, "enabled", text="")
+            row.prop(item, "node_tree", text="", icon='NODETREE')
+        elif self.layout_type in {'GRID'}:
+            layout.alignment = 'CENTER'
+            layout.prop(item, "enabled", text="")
+
+class FN_OT_mod_add(Operator):
+    bl_idname = "file_nodes.mod_add"
+    bl_label = "Add File Node Modifier"
+
+    def execute(self, context):
+        mods = context.scene.file_node_modifiers
+        item = mods.add()
+        tree = bpy.data.node_groups.new("File Nodes", 'FileNodesTreeType')
+        tree.use_fake_user = True
+        item.node_tree = tree
+        item.name = tree.name
+        item.stack_index = len(mods) - 1
+        context.scene.file_node_mod_index = len(mods) - 1
+        return {'FINISHED'}
+
+class FN_OT_mod_remove(Operator):
+    bl_idname = "file_nodes.mod_remove"
+    bl_label = "Remove File Node Modifier"
+
+    def execute(self, context):
+        mods = context.scene.file_node_modifiers
+        idx = context.scene.file_node_mod_index
+        if 0 <= idx < len(mods):
+            mods.remove(idx)
+            context.scene.file_node_mod_index = max(0, idx-1)
+            for i, m in enumerate(mods):
+                m.stack_index = i
+        return {'FINISHED'}
+
+class FN_OT_mod_move(Operator):
+    bl_idname = "file_nodes.mod_move"
+    bl_label = "Move File Node Modifier"
+
+    direction: bpy.props.EnumProperty(items=[('UP','Up',''),('DOWN','Down','')])
+
+    def execute(self, context):
+        mods = context.scene.file_node_modifiers
+        idx = context.scene.file_node_mod_index
+        if self.direction == 'UP' and idx > 0:
+            mods.move(idx, idx-1)
+            context.scene.file_node_mod_index = idx-1
+        elif self.direction == 'DOWN' and idx < len(mods)-1:
+            mods.move(idx, idx+1)
+            context.scene.file_node_mod_index = idx+1
+        for i, m in enumerate(mods):
+            m.stack_index = i
+        return {'FINISHED'}
+
+classes = (FileNodeModItem, FILE_NODES_UL_modifiers, FN_OT_mod_add, FN_OT_mod_remove, FN_OT_mod_move)
+
+def register():
+    for cls in classes:
+        bpy.utils.register_class(cls)
+    bpy.types.Scene.file_node_modifiers = bpy.props.CollectionProperty(type=FileNodeModItem)
+    bpy.types.Scene.file_node_mod_index = bpy.props.IntProperty(default=0)
+
+def unregister():
+    del bpy.types.Scene.file_node_modifiers
+    del bpy.types.Scene.file_node_mod_index
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/operators.py
+++ b/operators.py
@@ -9,15 +9,20 @@ class FN_OT_evaluate_all(Operator):
     bl_label = "Evaluate File Nodes"
 
     def execute(self, context):
-        trees = [nt for nt in bpy.data.node_groups if isinstance(nt, FileNodesTree) and nt.fn_enabled]
-        trees.sort(key=lambda t: t.fn_stack_index)
-        for tree in trees:
-            evaluate_tree(tree, context)
-        self.report({'INFO'}, f'Evaluated {len(trees)} File Node trees')
+        count = evaluate_tree(context)
+        self.report({'INFO'}, f'Evaluated {count} File Node trees')
         return {'FINISHED'}
 
 ### Evaluator ###
-def evaluate_tree(tree, context):
+def evaluate_tree(context):
+    count = 0
+    for mod in sorted(context.scene.file_node_modifiers, key=lambda m: m.stack_index):
+        if mod.enabled and mod.node_tree:
+            _evaluate_tree(mod.node_tree, context)
+            count += 1
+    return count
+
+def _evaluate_tree(tree, context):
     resolved = {}
 
     def eval_socket(sock):

--- a/ui.py
+++ b/ui.py
@@ -1,7 +1,7 @@
 
 import bpy
 from bpy.types import Panel
-from .tree import FileNodesTree
+from .modifiers import FILE_NODES_UL_modifiers
 
 class FILE_NODES_PT_global(Panel):
     bl_label = "File Nodes"
@@ -11,14 +11,13 @@ class FILE_NODES_PT_global(Panel):
 
     def draw(self, context):
         layout = self.layout
-        col = layout.column()
-        trees = [nt for nt in bpy.data.node_groups if isinstance(nt, FileNodesTree)]
-        trees.sort(key=lambda t: t.fn_stack_index)
-        for t in trees:
-            row = col.row(align=True)
-            row.prop(t, 'fn_enabled', text='')
-            row.label(text=t.name)
-            row.prop(t, 'fn_stack_index', text='')
+        scene = context.scene
+        layout.template_list("FILE_NODES_UL_modifiers", "", scene, "file_node_modifiers", scene, "file_node_mod_index")
+        row = layout.row(align=True)
+        row.operator('file_nodes.mod_add', text="", icon='ADD')
+        row.operator('file_nodes.mod_remove', text="", icon='REMOVE')
+        row.operator('file_nodes.mod_move', text="", icon='TRIA_UP').direction = 'UP'
+        row.operator('file_nodes.mod_move', text="", icon='TRIA_DOWN').direction = 'DOWN'
         layout.operator('file_nodes.evaluate', icon='FILE_REFRESH')
 
 def register():


### PR DESCRIPTION
## Summary
- add `FileNodeModItem` property group and operators to manage a modifier stack
- register modifier collection on `Scene`
- update evaluate operator to run enabled modifiers in order
- show and manage modifiers via UIList in the scene panel
- ensure new node trees get fake users so they persist

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68582fc3221c833089e0e7da61e72107