### PR TITLE
Add generic datablock nodes

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -4,13 +4,10 @@ from nodeitems_utils import NodeCategory, NodeItem, register_node_categories, un
 
 categories = [
     NodeCategory('FILE_NODES_CATEGORY', 'File Nodes', items=[
-        NodeItem('FNReadBlendNode'),
-        NodeItem('FNCreateWorldList'),
-        NodeItem('FNGetWorldByName'),
         NodeItem('FNGroupInputNode'),
         NodeItem('FNReadBlendNode'),
-        NodeItem('FNCreateWorldList'),
-        NodeItem('FNGetWorldByName'),
+        NodeItem('FNCreateList'),
+        NodeItem('FNGetItemByName'),
         NodeItem('FNSetWorldNode'),
         NodeItem('FNGroupOutputNode'),
     ]),

--- a/nodes/create_list.py
+++ b/nodes/create_list.py
@@ -1,33 +1,70 @@
-
 import bpy
 from bpy.types import Node
 from .base import FNBaseNode
-from ..sockets import FNSocketWorld, FNSocketWorldList
+from ..sockets import (
+    FNSocketScene, FNSocketObject, FNSocketCollection, FNSocketWorld,
+    FNSocketSceneList, FNSocketObjectList, FNSocketCollectionList, FNSocketWorldList,
+)
 
-class FNCreateWorldList(Node, FNBaseNode):
-    @classmethod
-    def poll(cls, ntree):
-        return ntree.bl_idname == "FileNodesTreeType"
-    bl_idname = "FNCreateWorldList"
-    bl_label = "Create World List"
+_socket_single = {
+    'SCENE': 'FNSocketScene',
+    'OBJECT': 'FNSocketObject',
+    'COLLECTION': 'FNSocketCollection',
+    'WORLD': 'FNSocketWorld',
+}
+_socket_list = {
+    'SCENE': 'FNSocketSceneList',
+    'OBJECT': 'FNSocketObjectList',
+    'COLLECTION': 'FNSocketCollectionList',
+    'WORLD': 'FNSocketWorldList',
+}
+
+class FNCreateList(Node, FNBaseNode):
+    bl_idname = "FNCreateList"
+    bl_label = "Create List"
+
+    data_type: bpy.props.EnumProperty(
+        name="Type",
+        items=[
+            ('SCENE', 'Scene', ''),
+            ('OBJECT', 'Object', ''),
+            ('COLLECTION', 'Collection', ''),
+            ('WORLD', 'World', ''),
+        ],
+        default='WORLD',
+        update=lambda self, context: self.update_sockets()
+    )
+
+    def update_sockets(self):
+        while self.inputs:
+            self.inputs.remove(self.inputs[-1])
+        while self.outputs:
+            self.outputs.remove(self.outputs[-1])
+        single = _socket_single[self.data_type]
+        lst = _socket_list[self.data_type]
+        self.inputs.new(single, f"{self.data_type.title()} 1")
+        self.inputs.new(single, f"{self.data_type.title()} 2")
+        self.outputs.new(lst, f"{self.data_type.title()}s")
 
     def init(self, context):
-        self.inputs.new('FNSocketWorld', "World 1")
-        self.inputs.new('FNSocketWorld', "World 2")
-        self.outputs.new('FNSocketWorldList', "Worlds")
+        self.update_sockets()
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "data_type", text="Type")
 
     def process(self, context, inputs):
+        output_name = f"{self.data_type.title()}s"
         lst = []
         for sock in self.inputs:
             if sock.is_linked:
-                # value will be resolved in evaluator
                 lst.append(inputs.get(sock.name))
             else:
-                if sock.value:
+                if getattr(sock, 'value', None):
                     lst.append(sock.value)
-        return {"Worlds": lst}
+        return {output_name: lst}
 
 def register():
-    bpy.utils.register_class(FNCreateWorldList)
+    bpy.utils.register_class(FNCreateList)
+
 def unregister():
-    bpy.utils.unregister_class(FNCreateWorldList)
+    bpy.utils.unregister_class(FNCreateList)

--- a/sockets.py
+++ b/sockets.py
@@ -14,6 +14,22 @@ class FNSocketScene(NodeSocket):
     def draw_color(self, context, node): return _color(0.6,0.9,1.0)
     value: bpy.props.PointerProperty(type=bpy.types.Scene)
 
+class FNSocketObject(NodeSocket):
+    bl_idname = "FNSocketObject"
+    bl_label = "Object"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='OBJECT_DATA')
+    def draw_color(self, context, node): return _color(0.9,0.6,0.4)
+    value: bpy.props.PointerProperty(type=bpy.types.Object)
+
+class FNSocketCollection(NodeSocket):
+    bl_idname = "FNSocketCollection"
+    bl_label = "Collection"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='OUTLINER_COLLECTION')
+    def draw_color(self, context, node): return _color(0.4,0.8,0.6)
+    value: bpy.props.PointerProperty(type=bpy.types.Collection)
+
 class FNSocketWorld(NodeSocket):
     bl_idname = "FNSocketWorld"
     bl_label = "World"
@@ -23,6 +39,27 @@ class FNSocketWorld(NodeSocket):
     value: bpy.props.PointerProperty(type=bpy.types.World)
 
 # List sockets just pass python lists at runtime
+class FNSocketSceneList(NodeSocket):
+    bl_idname = "FNSocketSceneList"
+    bl_label = "Scene List"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='SCENE_DATA')
+    def draw_color(self, context, node): return _color(0.6,0.9,1.0)
+
+class FNSocketObjectList(NodeSocket):
+    bl_idname = "FNSocketObjectList"
+    bl_label = "Object List"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='OBJECT_DATA')
+    def draw_color(self, context, node): return _color(0.9,0.6,0.4)
+
+class FNSocketCollectionList(NodeSocket):
+    bl_idname = "FNSocketCollectionList"
+    bl_label = "Collection List"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='OUTLINER_COLLECTION')
+    def draw_color(self, context, node): return _color(0.4,0.8,0.6)
+
 class FNSocketWorldList(NodeSocket):
     bl_idname = "FNSocketWorldList"
     bl_label = "World List"
@@ -30,9 +67,15 @@ class FNSocketWorldList(NodeSocket):
         layout.label(text=text or self.name, icon='WORLD')
     def draw_color(self, context, node): return _color(0.8,0.8,0.3)
 
+_all_sockets = (
+    FNSocketScene, FNSocketObject, FNSocketCollection, FNSocketWorld,
+    FNSocketSceneList, FNSocketObjectList, FNSocketCollectionList, FNSocketWorldList,
+)
+
 def register():
-    for cls in (FNSocketScene, FNSocketWorld, FNSocketWorldList):
+    for cls in _all_sockets:
         bpy.utils.register_class(cls)
+
 def unregister():
-    for cls in reversed((FNSocketScene, FNSocketWorld, FNSocketWorldList)):
+    for cls in reversed(_all_sockets):
         bpy.utils.unregister_class(cls)


### PR DESCRIPTION
## Summary
- extend sockets to support Scenes, Objects and Collections
- add Scenes/Objects/Collections/World outputs to Read Blend node
- generalize Create List and Get Item nodes for any datablock type
- update menu entries for new node classes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858334d62248330b181337c84a99048