### PR TITLE
Set square display shape for list sockets

### DIFF
--- a/sockets.py
+++ b/sockets.py
@@ -42,6 +42,7 @@ class FNSocketWorld(NodeSocket):
 class FNSocketSceneList(NodeSocket):
     bl_idname = "FNSocketSceneList"
     bl_label = "Scene List"
+    display_shape: str = 'SQUARE'
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='SCENE_DATA')
     def draw_color(self, context, node): return _color(0.6,0.9,1.0)
@@ -49,6 +50,7 @@ class FNSocketSceneList(NodeSocket):
 class FNSocketObjectList(NodeSocket):
     bl_idname = "FNSocketObjectList"
     bl_label = "Object List"
+    display_shape: str = 'SQUARE'
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='OBJECT_DATA')
     def draw_color(self, context, node): return _color(0.9,0.6,0.4)
@@ -56,6 +58,7 @@ class FNSocketObjectList(NodeSocket):
 class FNSocketCollectionList(NodeSocket):
     bl_idname = "FNSocketCollectionList"
     bl_label = "Collection List"
+    display_shape: str = 'SQUARE'
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='OUTLINER_COLLECTION')
     def draw_color(self, context, node): return _color(0.4,0.8,0.6)
@@ -63,6 +66,7 @@ class FNSocketCollectionList(NodeSocket):
 class FNSocketWorldList(NodeSocket):
     bl_idname = "FNSocketWorldList"
     bl_label = "World List"
+    display_shape: str = 'SQUARE'
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='WORLD')
     def draw_color(self, context, node): return _color(0.8,0.8,0.3)


### PR DESCRIPTION
## Summary
- draw custom list sockets as square connectors

## Testing
- `python -m py_compile sockets.py nodes/create_list.py nodes/get_item_by_name.py nodes/read_blend.py`

------
https://chatgpt.com/codex/tasks/task_e_68585364d71083308a6b02f824939ac8