### PR TITLE
Add sockets and support for more datablock types

### DIFF
--- a/nodes/create_list.py
+++ b/nodes/create_list.py
@@ -3,7 +3,11 @@ from bpy.types import Node
 from .base import FNBaseNode
 from ..sockets import (
     FNSocketScene, FNSocketObject, FNSocketCollection, FNSocketWorld,
+    FNSocketCamera, FNSocketImage, FNSocketLight, FNSocketMaterial,
+    FNSocketMesh, FNSocketNodeTree, FNSocketText, FNSocketWorkSpace,
     FNSocketSceneList, FNSocketObjectList, FNSocketCollectionList, FNSocketWorldList,
+    FNSocketCameraList, FNSocketImageList, FNSocketLightList, FNSocketMaterialList,
+    FNSocketMeshList, FNSocketNodeTreeList, FNSocketTextList, FNSocketWorkSpaceList,
 )
 
 _socket_single = {
@@ -11,12 +15,28 @@ _socket_single = {
     'OBJECT': 'FNSocketObject',
     'COLLECTION': 'FNSocketCollection',
     'WORLD': 'FNSocketWorld',
+    'CAMERA': 'FNSocketCamera',
+    'IMAGE': 'FNSocketImage',
+    'LIGHT': 'FNSocketLight',
+    'MATERIAL': 'FNSocketMaterial',
+    'MESH': 'FNSocketMesh',
+    'NODETREE': 'FNSocketNodeTree',
+    'TEXT': 'FNSocketText',
+    'WORKSPACE': 'FNSocketWorkSpace',
 }
 _socket_list = {
     'SCENE': 'FNSocketSceneList',
     'OBJECT': 'FNSocketObjectList',
     'COLLECTION': 'FNSocketCollectionList',
     'WORLD': 'FNSocketWorldList',
+    'CAMERA': 'FNSocketCameraList',
+    'IMAGE': 'FNSocketImageList',
+    'LIGHT': 'FNSocketLightList',
+    'MATERIAL': 'FNSocketMaterialList',
+    'MESH': 'FNSocketMeshList',
+    'NODETREE': 'FNSocketNodeTreeList',
+    'TEXT': 'FNSocketTextList',
+    'WORKSPACE': 'FNSocketWorkSpaceList',
 }
 
 class FNCreateList(Node, FNBaseNode):
@@ -30,6 +50,14 @@ class FNCreateList(Node, FNBaseNode):
             ('OBJECT', 'Object', ''),
             ('COLLECTION', 'Collection', ''),
             ('WORLD', 'World', ''),
+            ('CAMERA', 'Camera', ''),
+            ('IMAGE', 'Image', ''),
+            ('LIGHT', 'Light', ''),
+            ('MATERIAL', 'Material', ''),
+            ('MESH', 'Mesh', ''),
+            ('NODETREE', 'Node Tree', ''),
+            ('TEXT', 'Text', ''),
+            ('WORKSPACE', 'WorkSpace', ''),
         ],
         default='WORLD',
         update=lambda self, context: self.update_sockets()

--- a/nodes/get_item_by_name.py
+++ b/nodes/get_item_by_name.py
@@ -3,7 +3,11 @@ from bpy.types import Node
 from .base import FNBaseNode
 from ..sockets import (
     FNSocketScene, FNSocketObject, FNSocketCollection, FNSocketWorld,
+    FNSocketCamera, FNSocketImage, FNSocketLight, FNSocketMaterial,
+    FNSocketMesh, FNSocketNodeTree, FNSocketText, FNSocketWorkSpace,
     FNSocketSceneList, FNSocketObjectList, FNSocketCollectionList, FNSocketWorldList,
+    FNSocketCameraList, FNSocketImageList, FNSocketLightList, FNSocketMaterialList,
+    FNSocketMeshList, FNSocketNodeTreeList, FNSocketTextList, FNSocketWorkSpaceList,
 )
 
 _socket_single = {
@@ -11,12 +15,28 @@ _socket_single = {
     'OBJECT': 'FNSocketObject',
     'COLLECTION': 'FNSocketCollection',
     'WORLD': 'FNSocketWorld',
+    'CAMERA': 'FNSocketCamera',
+    'IMAGE': 'FNSocketImage',
+    'LIGHT': 'FNSocketLight',
+    'MATERIAL': 'FNSocketMaterial',
+    'MESH': 'FNSocketMesh',
+    'NODETREE': 'FNSocketNodeTree',
+    'TEXT': 'FNSocketText',
+    'WORKSPACE': 'FNSocketWorkSpace',
 }
 _socket_list = {
     'SCENE': 'FNSocketSceneList',
     'OBJECT': 'FNSocketObjectList',
     'COLLECTION': 'FNSocketCollectionList',
     'WORLD': 'FNSocketWorldList',
+    'CAMERA': 'FNSocketCameraList',
+    'IMAGE': 'FNSocketImageList',
+    'LIGHT': 'FNSocketLightList',
+    'MATERIAL': 'FNSocketMaterialList',
+    'MESH': 'FNSocketMeshList',
+    'NODETREE': 'FNSocketNodeTreeList',
+    'TEXT': 'FNSocketTextList',
+    'WORKSPACE': 'FNSocketWorkSpaceList',
 }
 
 class FNGetItemByName(Node, FNBaseNode):
@@ -30,6 +50,14 @@ class FNGetItemByName(Node, FNBaseNode):
             ('OBJECT', 'Object', ''),
             ('COLLECTION', 'Collection', ''),
             ('WORLD', 'World', ''),
+            ('CAMERA', 'Camera', ''),
+            ('IMAGE', 'Image', ''),
+            ('LIGHT', 'Light', ''),
+            ('MATERIAL', 'Material', ''),
+            ('MESH', 'Mesh', ''),
+            ('NODETREE', 'Node Tree', ''),
+            ('TEXT', 'Text', ''),
+            ('WORKSPACE', 'WorkSpace', ''),
         ],
         default='WORLD',
         update=lambda self, context: self.update_sockets()

--- a/nodes/read_blend.py
+++ b/nodes/read_blend.py
@@ -3,10 +3,9 @@ import bpy, os
 from bpy.types import Node
 from .base import FNBaseNode
 from ..sockets import (
-    FNSocketSceneList,
-    FNSocketObjectList,
-    FNSocketCollectionList,
-    FNSocketWorldList,
+    FNSocketSceneList, FNSocketObjectList, FNSocketCollectionList, FNSocketWorldList,
+    FNSocketCameraList, FNSocketImageList, FNSocketLightList, FNSocketMaterialList,
+    FNSocketMeshList, FNSocketNodeTreeList, FNSocketTextList, FNSocketWorkSpaceList,
 )
 
 class FNReadBlendNode(Node, FNBaseNode):
@@ -23,6 +22,14 @@ class FNReadBlendNode(Node, FNBaseNode):
         self.outputs.new('FNSocketObjectList', "Objects")
         self.outputs.new('FNSocketCollectionList', "Collections")
         self.outputs.new('FNSocketWorldList', "Worlds")
+        self.outputs.new('FNSocketCameraList', "Cameras")
+        self.outputs.new('FNSocketImageList', "Images")
+        self.outputs.new('FNSocketLightList', "Lights")
+        self.outputs.new('FNSocketMaterialList', "Materials")
+        self.outputs.new('FNSocketMeshList', "Meshes")
+        self.outputs.new('FNSocketNodeTreeList', "NodeTrees")
+        self.outputs.new('FNSocketTextList', "Texts")
+        self.outputs.new('FNSocketWorkSpaceList', "WorkSpaces")
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "filepath", text="")
@@ -30,14 +37,29 @@ class FNReadBlendNode(Node, FNBaseNode):
     def process(self, context, inputs):
         if not self.filepath or not os.path.isfile(bpy.path.abspath(self.filepath)):
             self.report({'WARNING'}, "Invalid filepath")
-            return {"Scenes": [], "Objects": [], "Collections": [], "Worlds": []}
+            return {
+                "Scenes": [], "Objects": [], "Collections": [], "Worlds": [],
+                "Cameras": [], "Images": [], "Lights": [], "Materials": [],
+                "Meshes": [], "NodeTrees": [], "Texts": [], "WorkSpaces": [],
+            }
         scenes_out, objects_out, collections_out, worlds_out = [], [], [], []
+        cameras_out, images_out, lights_out = [], [], []
+        materials_out, meshes_out, nodetrees_out = [], [], []
+        texts_out, workspaces_out = [], []
         abs_path = bpy.path.abspath(self.filepath)
         with bpy.data.libraries.load(abs_path, link=True) as (data_from, data_to):
             data_to.scenes = data_from.scenes
             data_to.objects = data_from.objects
             data_to.collections = data_from.collections
             data_to.worlds = data_from.worlds
+            data_to.cameras = data_from.cameras
+            data_to.images = data_from.images
+            data_to.lights = data_from.lights
+            data_to.materials = data_from.materials
+            data_to.meshes = data_from.meshes
+            data_to.node_groups = data_from.node_groups
+            data_to.texts = data_from.texts
+            data_to.workspaces = data_from.workspaces
         for s in data_to.scenes:
             scenes_out.append(s if isinstance(s, bpy.types.Scene) else bpy.data.scenes.get(s))
         for o in data_to.objects:
@@ -46,11 +68,35 @@ class FNReadBlendNode(Node, FNBaseNode):
             collections_out.append(c if isinstance(c, bpy.types.Collection) else bpy.data.collections.get(c))
         for w in data_to.worlds:
             worlds_out.append(w if isinstance(w, bpy.types.World) else bpy.data.worlds.get(w))
+        for cam in data_to.cameras:
+            cameras_out.append(cam if isinstance(cam, bpy.types.Camera) else bpy.data.cameras.get(cam))
+        for img in data_to.images:
+            images_out.append(img if isinstance(img, bpy.types.Image) else bpy.data.images.get(img))
+        for li in data_to.lights:
+            lights_out.append(li if isinstance(li, bpy.types.Light) else bpy.data.lights.get(li))
+        for mat in data_to.materials:
+            materials_out.append(mat if isinstance(mat, bpy.types.Material) else bpy.data.materials.get(mat))
+        for me in data_to.meshes:
+            meshes_out.append(me if isinstance(me, bpy.types.Mesh) else bpy.data.meshes.get(me))
+        for nt in data_to.node_groups:
+            nodetrees_out.append(nt if isinstance(nt, bpy.types.NodeTree) else bpy.data.node_groups.get(nt))
+        for txt in data_to.texts:
+            texts_out.append(txt if isinstance(txt, bpy.types.Text) else bpy.data.texts.get(txt))
+        for ws in data_to.workspaces:
+            workspaces_out.append(ws if isinstance(ws, bpy.types.WorkSpace) else bpy.data.workspaces.get(ws))
         return {
             "Scenes": scenes_out,
             "Objects": objects_out,
             "Collections": collections_out,
             "Worlds": worlds_out,
+            "Cameras": cameras_out,
+            "Images": images_out,
+            "Lights": lights_out,
+            "Materials": materials_out,
+            "Meshes": meshes_out,
+            "NodeTrees": nodetrees_out,
+            "Texts": texts_out,
+            "WorkSpaces": workspaces_out,
         }
 
 def register():

--- a/sockets.py
+++ b/sockets.py
@@ -30,6 +30,70 @@ class FNSocketCollection(NodeSocket):
     def draw_color(self, context, node): return _color(0.4,0.8,0.6)
     value: bpy.props.PointerProperty(type=bpy.types.Collection)
 
+class FNSocketCamera(NodeSocket):
+    bl_idname = "FNSocketCamera"
+    bl_label = "Camera"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='CAMERA_DATA')
+    def draw_color(self, context, node): return _color(0.8,0.6,0.4)
+    value: bpy.props.PointerProperty(type=bpy.types.Camera)
+
+class FNSocketImage(NodeSocket):
+    bl_idname = "FNSocketImage"
+    bl_label = "Image"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='IMAGE_DATA')
+    def draw_color(self, context, node): return _color(0.8,0.8,0.8)
+    value: bpy.props.PointerProperty(type=bpy.types.Image)
+
+class FNSocketLight(NodeSocket):
+    bl_idname = "FNSocketLight"
+    bl_label = "Light"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='LIGHT_DATA')
+    def draw_color(self, context, node): return _color(1.0,0.9,0.3)
+    value: bpy.props.PointerProperty(type=bpy.types.Light)
+
+class FNSocketMaterial(NodeSocket):
+    bl_idname = "FNSocketMaterial"
+    bl_label = "Material"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='MATERIAL_DATA')
+    def draw_color(self, context, node): return _color(0.9,0.6,0.8)
+    value: bpy.props.PointerProperty(type=bpy.types.Material)
+
+class FNSocketMesh(NodeSocket):
+    bl_idname = "FNSocketMesh"
+    bl_label = "Mesh"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='MESH_DATA')
+    def draw_color(self, context, node): return _color(0.6,0.6,1.0)
+    value: bpy.props.PointerProperty(type=bpy.types.Mesh)
+
+class FNSocketNodeTree(NodeSocket):
+    bl_idname = "FNSocketNodeTree"
+    bl_label = "Node Tree"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='NODETREE')
+    def draw_color(self, context, node): return _color(0.7,0.9,0.7)
+    value: bpy.props.PointerProperty(type=bpy.types.NodeTree)
+
+class FNSocketText(NodeSocket):
+    bl_idname = "FNSocketText"
+    bl_label = "Text"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='TEXT')
+    def draw_color(self, context, node): return _color(0.9,0.9,0.6)
+    value: bpy.props.PointerProperty(type=bpy.types.Text)
+
+class FNSocketWorkSpace(NodeSocket):
+    bl_idname = "FNSocketWorkSpace"
+    bl_label = "WorkSpace"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='WORKSPACE')
+    def draw_color(self, context, node): return _color(0.5,0.7,0.9)
+    value: bpy.props.PointerProperty(type=bpy.types.WorkSpace)
+
 class FNSocketWorld(NodeSocket):
     bl_idname = "FNSocketWorld"
     bl_label = "World"
@@ -71,9 +135,77 @@ class FNSocketWorldList(NodeSocket):
         layout.label(text=text or self.name, icon='WORLD')
     def draw_color(self, context, node): return _color(0.8,0.8,0.3)
 
+class FNSocketCameraList(NodeSocket):
+    bl_idname = "FNSocketCameraList"
+    bl_label = "Camera List"
+    display_shape: str = 'SQUARE'
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='CAMERA_DATA')
+    def draw_color(self, context, node): return _color(0.8,0.6,0.4)
+
+class FNSocketImageList(NodeSocket):
+    bl_idname = "FNSocketImageList"
+    bl_label = "Image List"
+    display_shape: str = 'SQUARE'
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='IMAGE_DATA')
+    def draw_color(self, context, node): return _color(0.8,0.8,0.8)
+
+class FNSocketLightList(NodeSocket):
+    bl_idname = "FNSocketLightList"
+    bl_label = "Light List"
+    display_shape: str = 'SQUARE'
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='LIGHT_DATA')
+    def draw_color(self, context, node): return _color(1.0,0.9,0.3)
+
+class FNSocketMaterialList(NodeSocket):
+    bl_idname = "FNSocketMaterialList"
+    bl_label = "Material List"
+    display_shape: str = 'SQUARE'
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='MATERIAL_DATA')
+    def draw_color(self, context, node): return _color(0.9,0.6,0.8)
+
+class FNSocketMeshList(NodeSocket):
+    bl_idname = "FNSocketMeshList"
+    bl_label = "Mesh List"
+    display_shape: str = 'SQUARE'
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='MESH_DATA')
+    def draw_color(self, context, node): return _color(0.6,0.6,1.0)
+
+class FNSocketNodeTreeList(NodeSocket):
+    bl_idname = "FNSocketNodeTreeList"
+    bl_label = "Node Tree List"
+    display_shape: str = 'SQUARE'
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='NODETREE')
+    def draw_color(self, context, node): return _color(0.7,0.9,0.7)
+
+class FNSocketTextList(NodeSocket):
+    bl_idname = "FNSocketTextList"
+    bl_label = "Text List"
+    display_shape: str = 'SQUARE'
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='TEXT')
+    def draw_color(self, context, node): return _color(0.9,0.9,0.6)
+
+class FNSocketWorkSpaceList(NodeSocket):
+    bl_idname = "FNSocketWorkSpaceList"
+    bl_label = "WorkSpace List"
+    display_shape: str = 'SQUARE'
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='WORKSPACE')
+    def draw_color(self, context, node): return _color(0.5,0.7,0.9)
+
 _all_sockets = (
     FNSocketScene, FNSocketObject, FNSocketCollection, FNSocketWorld,
+    FNSocketCamera, FNSocketImage, FNSocketLight, FNSocketMaterial,
+    FNSocketMesh, FNSocketNodeTree, FNSocketText, FNSocketWorkSpace,
     FNSocketSceneList, FNSocketObjectList, FNSocketCollectionList, FNSocketWorldList,
+    FNSocketCameraList, FNSocketImageList, FNSocketLightList, FNSocketMaterialList,
+    FNSocketMeshList, FNSocketNodeTreeList, FNSocketTextList, FNSocketWorkSpaceList,
 )
 
 def register():


### PR DESCRIPTION
## Summary
- add Camera, Image, Light, Material, Mesh, Node Tree, Text and WorkSpace sockets
- update Create List and Get Item by Name nodes for new datablocks
- extend Read Blend File node to output and load extra datablocks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858541d449483308254288b5de00030