### PR TITLE
Add input nodes and socket types

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -5,6 +5,18 @@ from nodeitems_utils import NodeCategory, NodeItem, register_node_categories, un
 categories = [
     NodeCategory('FILE_NODES_CATEGORY', 'File Nodes', items=[
         NodeItem('FNGroupInputNode'),
+        NodeItem('FNBoolInputNode'),
+        NodeItem('FNFloatInputNode'),
+        NodeItem('FNIntInputNode'),
+        NodeItem('FNStringInputNode'),
+        NodeItem('FNCameraInputNode'),
+        NodeItem('FNImageInputNode'),
+        NodeItem('FNLightInputNode'),
+        NodeItem('FNMaterialInputNode'),
+        NodeItem('FNMeshInputNode'),
+        NodeItem('FNNodeTreeInputNode'),
+        NodeItem('FNTextInputNode'),
+        NodeItem('FNWorkSpaceInputNode'),
         NodeItem('FNReadBlendNode'),
         NodeItem('FNCreateList'),
         NodeItem('FNGetItemByName'),

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -1,8 +1,8 @@
 
 import bpy, importlib
-from . import read_blend, create_list, get_item_by_name, set_world, group_input, group_output
+from . import read_blend, create_list, get_item_by_name, set_world, group_input, group_output, input_nodes
 
-_modules = [read_blend, create_list, get_item_by_name, set_world, group_input, group_output]
+_modules = [read_blend, create_list, get_item_by_name, set_world, group_input, group_output, input_nodes]
 
 def register():
     for m in _modules:

--- a/nodes/input_nodes.py
+++ b/nodes/input_nodes.py
@@ -1,0 +1,219 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..sockets import (
+    FNSocketBool, FNSocketFloat, FNSocketInt, FNSocketString,
+    FNSocketCamera, FNSocketImage, FNSocketLight, FNSocketMaterial,
+    FNSocketMesh, FNSocketNodeTree, FNSocketText, FNSocketWorkSpace,
+)
+
+
+class FNBoolInputNode(Node, FNBaseNode):
+    bl_idname = "FNBoolInputNode"
+    bl_label = "Boolean Input"
+
+    value: bpy.props.BoolProperty(name="Value")
+
+    def init(self, context):
+        self.outputs.new('FNSocketBool', "Boolean")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "value", text="Value")
+
+    def process(self, context, inputs):
+        return {"Boolean": self.value}
+
+
+class FNFloatInputNode(Node, FNBaseNode):
+    bl_idname = "FNFloatInputNode"
+    bl_label = "Float Input"
+
+    value: bpy.props.FloatProperty(name="Value")
+
+    def init(self, context):
+        self.outputs.new('FNSocketFloat', "Float")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "value", text="Value")
+
+    def process(self, context, inputs):
+        return {"Float": self.value}
+
+
+class FNIntInputNode(Node, FNBaseNode):
+    bl_idname = "FNIntInputNode"
+    bl_label = "Integer Input"
+
+    value: bpy.props.IntProperty(name="Value")
+
+    def init(self, context):
+        self.outputs.new('FNSocketInt', "Integer")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "value", text="Value")
+
+    def process(self, context, inputs):
+        return {"Integer": self.value}
+
+
+class FNStringInputNode(Node, FNBaseNode):
+    bl_idname = "FNStringInputNode"
+    bl_label = "String Input"
+
+    value: bpy.props.StringProperty(name="Value")
+
+    def init(self, context):
+        self.outputs.new('FNSocketString', "String")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "value", text="Value")
+
+    def process(self, context, inputs):
+        return {"String": self.value}
+
+
+class FNCameraInputNode(Node, FNBaseNode):
+    bl_idname = "FNCameraInputNode"
+    bl_label = "Camera Input"
+
+    value: bpy.props.PointerProperty(type=bpy.types.Camera)
+
+    def init(self, context):
+        self.outputs.new('FNSocketCamera', "Camera")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "value", text="Camera")
+
+    def process(self, context, inputs):
+        return {"Camera": self.value}
+
+
+class FNImageInputNode(Node, FNBaseNode):
+    bl_idname = "FNImageInputNode"
+    bl_label = "Image Input"
+
+    value: bpy.props.PointerProperty(type=bpy.types.Image)
+
+    def init(self, context):
+        self.outputs.new('FNSocketImage', "Image")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "value", text="Image")
+
+    def process(self, context, inputs):
+        return {"Image": self.value}
+
+
+class FNLightInputNode(Node, FNBaseNode):
+    bl_idname = "FNLightInputNode"
+    bl_label = "Light Input"
+
+    value: bpy.props.PointerProperty(type=bpy.types.Light)
+
+    def init(self, context):
+        self.outputs.new('FNSocketLight', "Light")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "value", text="Light")
+
+    def process(self, context, inputs):
+        return {"Light": self.value}
+
+
+class FNMaterialInputNode(Node, FNBaseNode):
+    bl_idname = "FNMaterialInputNode"
+    bl_label = "Material Input"
+
+    value: bpy.props.PointerProperty(type=bpy.types.Material)
+
+    def init(self, context):
+        self.outputs.new('FNSocketMaterial', "Material")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "value", text="Material")
+
+    def process(self, context, inputs):
+        return {"Material": self.value}
+
+
+class FNMeshInputNode(Node, FNBaseNode):
+    bl_idname = "FNMeshInputNode"
+    bl_label = "Mesh Input"
+
+    value: bpy.props.PointerProperty(type=bpy.types.Mesh)
+
+    def init(self, context):
+        self.outputs.new('FNSocketMesh', "Mesh")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "value", text="Mesh")
+
+    def process(self, context, inputs):
+        return {"Mesh": self.value}
+
+
+class FNNodeTreeInputNode(Node, FNBaseNode):
+    bl_idname = "FNNodeTreeInputNode"
+    bl_label = "Node Tree Input"
+
+    value: bpy.props.PointerProperty(type=bpy.types.NodeTree)
+
+    def init(self, context):
+        self.outputs.new('FNSocketNodeTree', "Node Tree")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "value", text="Node Tree")
+
+    def process(self, context, inputs):
+        return {"Node Tree": self.value}
+
+
+class FNTextInputNode(Node, FNBaseNode):
+    bl_idname = "FNTextInputNode"
+    bl_label = "Text Input"
+
+    value: bpy.props.PointerProperty(type=bpy.types.Text)
+
+    def init(self, context):
+        self.outputs.new('FNSocketText', "Text")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "value", text="Text")
+
+    def process(self, context, inputs):
+        return {"Text": self.value}
+
+
+class FNWorkSpaceInputNode(Node, FNBaseNode):
+    bl_idname = "FNWorkSpaceInputNode"
+    bl_label = "WorkSpace Input"
+
+    value: bpy.props.PointerProperty(type=bpy.types.WorkSpace)
+
+    def init(self, context):
+        self.outputs.new('FNSocketWorkSpace', "WorkSpace")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "value", text="WorkSpace")
+
+    def process(self, context, inputs):
+        return {"WorkSpace": self.value}
+
+
+_classes = (
+    FNBoolInputNode, FNFloatInputNode, FNIntInputNode, FNStringInputNode,
+    FNCameraInputNode, FNImageInputNode, FNLightInputNode, FNMaterialInputNode,
+    FNMeshInputNode, FNNodeTreeInputNode, FNTextInputNode, FNWorkSpaceInputNode,
+)
+
+
+def register():
+    for cls in _classes:
+        bpy.utils.register_class(cls)
+
+
+def unregister():
+    for cls in reversed(_classes):
+        bpy.utils.unregister_class(cls)
+

--- a/sockets.py
+++ b/sockets.py
@@ -5,6 +5,39 @@ from bpy.types import NodeSocket
 ### Helpers ###
 def _color(r,g,b): return (r,g,b,1.0)
 
+# Basic value sockets
+class FNSocketBool(NodeSocket):
+    bl_idname = "FNSocketBool"
+    bl_label = "Boolean"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='CHECKBOX_HLT')
+    def draw_color(self, context, node): return _color(0.8, 0.8, 0.2)
+    value: bpy.props.BoolProperty()
+
+class FNSocketFloat(NodeSocket):
+    bl_idname = "FNSocketFloat"
+    bl_label = "Float"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='PROP_FLOAT')
+    def draw_color(self, context, node): return _color(0.6, 0.8, 0.9)
+    value: bpy.props.FloatProperty()
+
+class FNSocketInt(NodeSocket):
+    bl_idname = "FNSocketInt"
+    bl_label = "Integer"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='SORTSIZE')
+    def draw_color(self, context, node): return _color(0.9, 0.7, 0.5)
+    value: bpy.props.IntProperty()
+
+class FNSocketString(NodeSocket):
+    bl_idname = "FNSocketString"
+    bl_label = "String"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='FONT_DATA')
+    def draw_color(self, context, node): return _color(0.7, 0.7, 0.7)
+    value: bpy.props.StringProperty()
+
 # Single datablock sockets
 class FNSocketScene(NodeSocket):
     bl_idname = "FNSocketScene"
@@ -200,6 +233,7 @@ class FNSocketWorkSpaceList(NodeSocket):
     def draw_color(self, context, node): return _color(0.5,0.7,0.9)
 
 _all_sockets = (
+    FNSocketBool, FNSocketFloat, FNSocketInt, FNSocketString,
     FNSocketScene, FNSocketObject, FNSocketCollection, FNSocketWorld,
     FNSocketCamera, FNSocketImage, FNSocketLight, FNSocketMaterial,
     FNSocketMesh, FNSocketNodeTree, FNSocketText, FNSocketWorkSpace,


### PR DESCRIPTION
## Summary
- implement sockets for Bool/Float/Int/String
- add input nodes for various basic and datablock types
- update node registry and menu to expose new inputs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858576c761883309e971558812f8bfa