### PR TITLE
Add output to Set World node

### DIFF
--- a/nodes/set_world.py
+++ b/nodes/set_world.py
@@ -14,13 +14,14 @@ class FNSetWorld(Node, FNBaseNode):
     def init(self, context):
         self.inputs.new('FNSocketScene', "Scene")
         self.inputs.new('FNSocketWorld', "World")
+        self.outputs.new('FNSocketScene', "Scene")
 
     def process(self, context, inputs):
         scene = inputs.get("Scene")
         world = inputs.get("World")
         if scene and world:
             scene.world = world
-        return {}
+        return {"Scene": scene}
 
 def register():
     bpy.utils.register_class(FNSetWorld)


### PR DESCRIPTION
## Summary
- allow `Set World to Scene` node to output the modified scene

## Testing
- `python -m py_compile nodes/set_world.py`


------
https://chatgpt.com/codex/tasks/task_e_68585ab98ca08330843446bcf088b2c7