### PR TITLE
Fix property update callback compatibility

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -15,8 +15,10 @@ class FN_OT_evaluate_all(Operator):
         return {'FINISHED'}
 
 
-def auto_evaluate_if_enabled(context=None):
+def auto_evaluate_if_enabled(self=None, context=None):
     """Evaluate all file node trees if the preference is enabled."""
+    if context is None and isinstance(self, bpy.types.Context):
+        context = self
     context = context or bpy.context
     prefs = context.preferences.addons.get(ADDON_NAME)
     if prefs and prefs.preferences.auto_evaluate:


### PR DESCRIPTION
## Summary
- fix `auto_evaluate_if_enabled` signature for Blender 4.4 update callbacks

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68585dbbc6d48330b124fb32d3e4eaa6