### PR TITLE
Remove world socket from group output node

### DIFF
--- a/nodes/group_output.py
+++ b/nodes/group_output.py
@@ -2,7 +2,7 @@
 import bpy
 from bpy.types import Node
 from .base import FNBaseNode
-from ..sockets import FNSocketScene, FNSocketWorld
+from ..sockets import FNSocketScene
 
 class FNGroupOutputNode(Node, FNBaseNode):
     bl_idname = "FNGroupOutputNode"
@@ -14,7 +14,6 @@ class FNGroupOutputNode(Node, FNBaseNode):
 
     def init(self, context):
         self.inputs.new('FNSocketScene', "Scene")
-        self.inputs.new('FNSocketWorld', "World")
 
     def process(self, context, inputs):
         # Terminal node, no action needed


### PR DESCRIPTION
## Summary
- remove unused `FNSocketWorld` import and socket from `FNGroupOutputNode`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685862796594833090714bd3335cbcf9