### PR TITLE
Add FNWorldInputNode

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -9,6 +9,7 @@ categories = [
         NodeItem('FNFloatInputNode'),
         NodeItem('FNIntInputNode'),
         NodeItem('FNStringInputNode'),
+        NodeItem('FNWorldInputNode'),
         NodeItem('FNCameraInputNode'),
         NodeItem('FNImageInputNode'),
         NodeItem('FNLightInputNode'),

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -1,5 +1,7 @@
 
 import bpy, importlib
+# Node modules used by the File Nodes addon. `input_nodes` now contains
+# FNWorldInputNode for providing World datablocks.
 from . import read_blend, create_list, get_item_by_name, set_world, group_input, group_output, input_nodes
 
 _modules = [read_blend, create_list, get_item_by_name, set_world, group_input, group_output, input_nodes]

--- a/nodes/input_nodes.py
+++ b/nodes/input_nodes.py
@@ -5,7 +5,7 @@ from ..operators import auto_evaluate_if_enabled
 from .base import FNBaseNode
 from ..sockets import (
     FNSocketBool, FNSocketFloat, FNSocketInt, FNSocketString,
-    FNSocketCamera, FNSocketImage, FNSocketLight, FNSocketMaterial,
+    FNSocketWorld, FNSocketCamera, FNSocketImage, FNSocketLight, FNSocketMaterial,
     FNSocketMesh, FNSocketNodeTree, FNSocketText, FNSocketWorkSpace,
 )
 
@@ -72,6 +72,22 @@ class FNStringInputNode(Node, FNBaseNode):
 
     def process(self, context, inputs):
         return {"String": self.value}
+
+
+class FNWorldInputNode(Node, FNBaseNode):
+    bl_idname = "FNWorldInputNode"
+    bl_label = "World Input"
+
+    value: bpy.props.PointerProperty(type=bpy.types.World, update=auto_evaluate_if_enabled)
+
+    def init(self, context):
+        self.outputs.new('FNSocketWorld', "World")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "value", text="World")
+
+    def process(self, context, inputs):
+        return {"World": self.value}
 
 
 class FNCameraInputNode(Node, FNBaseNode):
@@ -204,7 +220,7 @@ class FNWorkSpaceInputNode(Node, FNBaseNode):
 
 _classes = (
     FNBoolInputNode, FNFloatInputNode, FNIntInputNode, FNStringInputNode,
-    FNCameraInputNode, FNImageInputNode, FNLightInputNode, FNMaterialInputNode,
+    FNWorldInputNode, FNCameraInputNode, FNImageInputNode, FNLightInputNode, FNMaterialInputNode,
     FNMeshInputNode, FNNodeTreeInputNode, FNTextInputNode, FNWorkSpaceInputNode,
 )
 


### PR DESCRIPTION
## Summary
- add `FNWorldInputNode` that outputs a chosen world datablock
- integrate the node with registration lists
- list the new node in the Add menu
- document new node module in package init

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68586282d1408330bb28c59a95bfe375