### PR TITLE
Support modifier exposed input values

### DIFF
--- a/nodes/group_input.py
+++ b/nodes/group_input.py
@@ -2,6 +2,7 @@
 import bpy
 from bpy.types import Node
 from .base import FNBaseNode
+from ..operators import get_active_mod_item
 
 
 def _interface_inputs(tree):
@@ -44,9 +45,12 @@ class FNGroupInputNode(Node, FNBaseNode):
 
     def process(self, context, inputs):
         outputs = {}
+        mod = get_active_mod_item()
         for item in _interface_inputs(self.id_data):
             if item.name == "Scene":
                 outputs[item.name] = context.scene
+            elif mod:
+                outputs[item.name] = mod.get_input_value(item.name)
             else:
                 outputs[item.name] = None
         return outputs

--- a/operators.py
+++ b/operators.py
@@ -5,6 +5,11 @@ from bpy.types import Operator
 from collections import deque
 from . import ADDON_NAME
 
+_active_mod_item = None
+
+def get_active_mod_item():
+    return _active_mod_item
+
 class FN_OT_evaluate_all(Operator):
     bl_idname = "file_nodes.evaluate"
     bl_label = "Evaluate File Nodes"
@@ -26,10 +31,13 @@ def auto_evaluate_if_enabled(self=None, context=None):
 
 ### Evaluator ###
 def evaluate_tree(context):
+    global _active_mod_item
     count = 0
     for mod in sorted(context.scene.file_node_modifiers, key=lambda m: m.stack_index):
         if mod.enabled and mod.node_tree:
+            _active_mod_item = mod
             _evaluate_tree(mod.node_tree, context)
+            _active_mod_item = None
             count += 1
     return count
 

--- a/ui.py
+++ b/ui.py
@@ -1,7 +1,7 @@
 
 import bpy
 from bpy.types import Panel
-from .modifiers import FILE_NODES_UL_modifiers
+from .modifiers import FILE_NODES_UL_modifiers, FileNodeModItem
 from . import ADDON_NAME
 
 class FILE_NODES_PT_global(Panel):
@@ -19,6 +19,16 @@ class FILE_NODES_PT_global(Panel):
         row.operator('file_nodes.mod_remove', text="", icon='REMOVE')
         row.operator('file_nodes.mod_move', text="", icon='TRIA_UP').direction = 'UP'
         row.operator('file_nodes.mod_move', text="", icon='TRIA_DOWN').direction = 'DOWN'
+
+        if 0 <= scene.file_node_mod_index < len(scene.file_node_modifiers):
+            mod = scene.file_node_modifiers[scene.file_node_mod_index]
+            mod.sync_inputs()
+            box = layout.box()
+            for inp in mod.inputs:
+                prop = inp.prop_name()
+                if prop:
+                    box.prop(inp, prop, text=inp.name)
+
         layout.operator('file_nodes.evaluate', icon='FILE_REFRESH')
         prefs = context.preferences.addons[ADDON_NAME].preferences
         layout.prop(prefs, "auto_evaluate")


### PR DESCRIPTION
## Summary
- store exposed input values on `FileNodeModItem`
- draw modifier inputs in the Scene panel
- supply modifier values to the Group Input node
- keep track of the active modifier during evaluation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685864e702b8833083c2d2826ae0810e