### PR TITLE
Fix UI add-on error in File-Nodes

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -35,6 +35,7 @@ def evaluate_tree(context):
     count = 0
     for mod in sorted(context.scene.file_node_modifiers, key=lambda m: m.stack_index):
         if mod.enabled and mod.node_tree:
+            mod.sync_inputs()
             _active_mod_item = mod
             _evaluate_tree(mod.node_tree, context)
             _active_mod_item = None

--- a/ui.py
+++ b/ui.py
@@ -22,7 +22,6 @@ class FILE_NODES_PT_global(Panel):
 
         if 0 <= scene.file_node_mod_index < len(scene.file_node_modifiers):
             mod = scene.file_node_modifiers[scene.file_node_mod_index]
-            mod.sync_inputs()
             box = layout.box()
             for inp in mod.inputs:
                 prop = inp.prop_name()


### PR DESCRIPTION
## Summary
- don't mutate modifier inputs in `draw` to avoid context error
- sync modifier inputs when node trees are evaluated

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858675b26848330865401903df9f31e