### PR TITLE
Improve README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,249 +1,36 @@
-# File-Nodes
-Introducción y Objetivos del Addon
-El addon File Nodes busca introducir en Blender un sistema nodal procedural a nivel de archivos y datablocks, análogo a Geometry Nodes pero operando sobre la estructura de datos de Blender en lugar de geometría. El objetivo del MVP (Producto Mínimo Viable) es proveer a desarrolladores las bases de este sistema, permitiendo construir flujos de trabajo nodales para gestionar datablocks (escenas, objetos, colecciones, mundos, etc.) tanto del archivo .blend actual como de archivos externos. En este MVP se implementarán nodos clave que demuestren la funcionalidad esencial:
-Nodo Group Input: para exponer datablocks del archivo actual dentro del sistema nodal (por ejemplo, la escena activa u otros elementos pasados como entrada).
-Nodo Read Blend File: para leer datablocks desde archivos .blend externos especificados, obteniéndolos de forma no destructiva.
-Listas de datablocks: los nodos anteriores proveen sus resultados como listas tipadas (lista de objetos, lista de escenas, lista de colecciones, lista de mundos).
-Nodos de operación sobre listas: por ejemplo Get Item by Name (buscar un elemento por nombre dentro de una lista) y Create List (construir manualmente una lista de elementos).
-Nodo Set World to Scene: que permite, a modo de prueba de modificación, asignar un World a una Scene destino, demostrando cómo el sistema nodal puede alterar un datablock de destino.
-Requisitos Técnicos: El addon está orientado a Blender 4.4+ y escrito en Python. Se creará un editor de nodos personalizado (nuevo tipo de NodeTree) con sus propias clases de nodos. Además, el sistema nodal debe integrarse con un concepto de “modificadores de archivo” apilables a nivel de Scene –similar al modifier stack de Geometry Nodes pero actuando sobre la Scene/archivo completo–. La ejecución de los nodos debe ser determinista y sin estado, garantizando que los mismos inputs produzcan siempre los mismos resultados, sin efectos colaterales ocultos. En las secciones siguientes se detallan la arquitectura general, el diseño de los nodos del MVP, el modelo de ejecución y stack de modificadores, la especificación de la interfaz (sockets y tipos de datos), y la gestión de datablocks con énfasis en no interferir con la edición manual directa. Este documento técnico servirá como referencia para el equipo de desarrollo, usando un lenguaje preciso orientado a programadores familiarizados con la API de Blender en Python y la creación de editores de nodos.
-Arquitectura General del Sistema
-Visión general: File Nodes introduce un nuevo tipo de NodeTree custom (p.ej. bpy.types.FileNodeTree) que representa un grafo de nodos conectados cuya función es “leer, combinar y aplicar datos de archivos .blend”. Este NodeTree personalizado aparece como un nuevo editor de nodos en Blender (similar a “Shader Editor”, “Geometry Node Editor”, etc.), con su propio espacio de trabajo. Al registrar la clase NodeTree con un bl_idname único, Blender la reconoce y la lista entre los editores de nodos disponibles (por ejemplo, usando Shift+F3 se puede ciclar entre editores hasta encontrar el nuevo tipo custom, según reportes de Blender 4.2+
-blender.stackexchange.com
-). Internamente, la arquitectura consta de los siguientes componentes principales:
-Clase NodeTree personalizada: define el contenedor del grafo. Por ejemplo, class FileNodesTree(bpy.types.NodeTree), con su bl_idname = "FileNodesTree" y bl_label = "File Nodes". Esta clase puede definir un método de clase poll para controlar en qué contextos aparece el editor (p.ej. solo en modo objeto o siempre disponible)
-docs.blender.org
-. El NodeTree es un ID data-block, por lo que Blender lo almacenará en bpy.data.node_groups (como hace con Geometry Nodes, Compositor, etc.), permitiendo que se comparta o guarde en el .blend actual.
-Clases de Node personalizadas: cada tipo de nodo (Read Blend File, Set World to Scene, etc.) se implementa heredando de bpy.types.Node. Se definen con un bl_idname y bl_label únicos, y especifican los sockets de entrada/salida que poseen. La clase NodeTree define qué nodos son permitidos en ella mediante el atributo Node.poll de cada nodo o de la NodeTree (se suele usar Node.poll para comprobar tree.bl_idname y así restringir qué nodos aparecen en nuestro editor personalizado).
-Sockets personalizados: dado que trabajaremos con tipos de datos no cubiertos por sockets estándar (como listas de objetos, escenas, etc.), es necesario definir bpy.types.NodeSocket personalizados (por ejemplo, FileNodesObjectListSocket, FileNodesSceneSocket, etc.). Estos sockets manejarán referencias a datablocks de Blender. Cada socket tendrá su propio bl_idname, bl_label y un color o icono distintivo en el editor. Es importante definir su propiedad de Python interna para almacenar el valor; por ejemplo, podría usarse una lista de nombres o directamente almacenar referencias a objetos Blender. Al ser Python, podemos almacenar listas de IDs de Blender (bpy.types.Object, Scene, etc.) directamente como datos temporales durante la evaluación nodal (más sobre esto en Modelo de Ejecución).
-Integración con la Scene (File Modifiers): para aplicar el NodeTree, se introduce el concepto de “modificador de archivo” a nivel de Scene. Esto se puede implementar añadiendo una propiedad en bpy.types.Scene que apunte a uno o varios NodeTrees de File Nodes. Dado que Blender no provee aún un enlace nativo para NodeTrees personalizados en datablocks (limitación histórica
-wiki.blender.jp
-), utilizaremos un PropertyGroup de Python que actúe como contenedor. Por ejemplo, Scene.file_node_modifiers podría ser una CollectionProperty de items, donde cada item tiene un PointerProperty apuntando a un FileNodesTree. Cada “item” de esta colección sería análogo a un modifier en el stack: con campos como nombre, habilitado, y la referencia al NodeTree. Esta colección permite apilar múltiples NodeTrees (modificadores) y eventualmente reordenarlos.
-UI del modifier: se proveerá un Panel en las propiedades de la Scene (contexto Scene en la Properties Editor) donde el usuario pueda gestionar estos File Node Modifiers. Este panel listará los NodeTrees asignados (similar a la lista de modifiers de objeto), con botones para añadir/quitar, un checkbox para activar/desactivar cada uno, y quizás flechas para cambiar el orden. Cada item mostrará también el nombre del NodeTree asociado (y posiblemente un menú desplegable para seleccionar un NodeTree existente o crear uno nuevo). Nota: Debido a que la API de Blender no soporta de forma directa asociar un NodeTree custom a una Scene con la misma facilidad que un Geometry Nodes modifier a un objeto (que en C++ tiene un campo Modifier.node_group), esta implementación en Python requiere manejar manualmente referencias y actualizaciones (e.g., si se renombra el NodeTree, actualizar referencias, uso de fake user, etc.)
-wiki.blender.jp
-wiki.blender.jp
-.
-Comportamiento no destructivo: los File Node Modifiers almacenan automáticamente los valores originales de cada dato que modifican. Antes de cada evaluación se restablecen esos valores y se aplica de nuevo el node tree, emulando el modo en que Geometry Nodes muestra una geometría modificada sin alterar la malla base. Si se desactiva o elimina un modificador, el addon restaura los datos originales.
-Determinismo y Sin Estado: El diseño asegura que la ejecución de un File NodeTree no deja información de estado persistente entre ejecuciones. No se utilizan variables globales que conserven datos de una ejecución a otra; cada evaluación recorre el grafo y produce un resultado desde cero. Esto evita comportamientos inesperados y facilita que el sistema sea determinista. Si se vuelve a ejecutar el mismo NodeTree con los mismos inputs (mismas escenas origen, mismos archivos externos), el resultado debe ser idéntico. Este principio es análogo a Geometry Nodes, donde el modificador recalcula la geometría fresh en cada cambio sin acumular estado oculto. Además, el sistema File Nodes opera de forma lazily evaluada solo cuando es necesario (por ejemplo, al inicializar o cuando algún input cambia) para integrarse con la Dependency Graph de Blender. Sin embargo, a diferencia de nodos nativos (que tienen evaluadores en C++), aquí la evaluación será manejada por Python. En Blender 4.x no existe la posibilidad de inyectar código Python en el evaluador nativo de nodos – es decir, no podemos hacer que Blender llame automáticamente a funciones Python para calcular cada nodo como parte de su pipeline de depsgraph
-blender.stackexchange.com
-. Por ello, implementaremos nuestro propio motor de evaluación (ver sección Modelo de Ejecución), asegurándonos de dispararlo en los momentos adecuados (p. ej., al cargar el archivo, al cambiar un parámetro en un nodo, o manualmente via un operador "Actualizar File Nodes"). Es posible apoyarse en handlers (depsgraph_update_post o similares) para activar la re-evaluación cuando cambien ciertos datos; sin embargo, se debe ser cuidadoso con el rendimiento y posibles loops de actualización. En resumen, la arquitectura general define una nueva infraestructura de nodos con sus propias clases y las engancha a Blender mediante propiedades en Scene, proporcionando la base para construir funcionalidades más complejas en iteraciones futuras (por ejemplo, importar objetos, gestionar overrides, etc.) sin modificar el núcleo de Blender, sino usando la API de Python de manera estructurada.
-Diseño del Sistema Nodal (Nodos Clave del MVP)
-En el MVP se implementarán varios nodos personalizados que ilustran las capacidades del sistema File Nodes. A continuación se describen los nodos principales, sus propósitos y diseño de sockets:
-Group Input (Entradas de Grupo): Este nodo representa las entradas externas al node tree, similar al Group Input en Geometry Nodes. En nuestro contexto, sirve para exponer datablocks del archivo actual al sistema nodal. Por ejemplo, podemos definir que el FileNodesTree tenga una entrada llamada "Scene Origen" (de tipo Scene) que por defecto esté vinculada a la escena activa o a la escena a la cual se aplica el modificador. También se podrían exponer otras entradas (por ejemplo, un World de origen, o un string de ruta de archivo, etc.) según las necesidades del node tree. Estas entradas se definen en la interfaz del NodeTree. En Blender 4.x, las entradas/salidas de un node group ya no se manejan directamente con node_tree.inputs.new(), sino vía node_tree.interface.new_socket(...)
-b3d.interplanety.org
-b3d.interplanety.org
-. Por simplicidad, podríamos predefinir al menos una entrada: Scene (Scene actual) y quizás Scene Target (la Scene destino a modificar, aunque en muchos casos será la misma). Nota: El nodo Group Input aparece automáticamente en el editor cuando NodeTree.bl_use_group_interface es True, mostrando los sockets definidos en la interfaz del node tree
-docs.blender.org
-. El desarrollador puede arrastrar conexiones desde estos sockets para usarlos dentro del grafo.
-Read Blend File: Nodo fundamental que permite leer datablocks desde un archivo .blend externo. Este nodo tendría típicamente:
-Propiedad: una ruta de archivo o selector de archivo (.blend).
-Salidas: una o varias listas de datos. Para el MVP se contemplan cuatro tipos de datos: Scenes, Collections, Objects y Worlds. Existen dos enfoques de diseño:
-Múltiples salidas especializadas: por ejemplo, una salida "Scenes" (lista de Scene), "Collections" (lista de Collection), "Objects" (lista de Object) y "Worlds" (lista de World). Este diseño permite conectar directamente solo el tipo de dato que interese en cada caso. El nodo, al ejecutarse, intentará abrir el archivo especificado en modo lectura de librería y poblar cada lista con los elementos correspondientes. Si el archivo contiene N escenas, la salida Scenes contendrá referencias a esas Scene (como datablocks linkeados en modo library linking, no copiados)
-docs.blender.org
-. Similar para objetos, colecciones y mundos.
-Salida única genérica: el nodo podría tener una sola salida de tipo genérico (por ejemplo, BlendData o una lista de ID) conteniendo todo, pero esto complicaría luego filtrar por tipo. Para claridad en este MVP se prefiere la primera opción (salidas separadas por tipo).
-Funcionamiento interno: Al activarse (ver modelo de ejecución), este nodo usará probablemente bpy.data.libraries.load o el contexto de with bpy.data.libraries.load(filepath) as (data_from, data_to): ... para vincular datos
-docs.blender.org
-. Para evitar cargar datos innecesarios, podemos limitar qué datablocks linkear: Blender permite especificar listas de nombres a cargar por tipo. En este MVP, Read Blend File sin filtros podría cargar todos los objetos, escenas, colecciones y mundos del archivo. Alternativamente, se podría dar opciones al usuario (por ejemplo, un filtro de nombre o de tipos a cargar), pero se sale del alcance básico.
-Datablocks linkeados: Importante mencionar que los datos traídos de un archivo externo vía linking son referencias no editables en el .blend actual
-docs.blender.org
-. Esto es deseable ya que encaja con la filosofía de que File Nodes no debe permitir editar directamente datos externos, solo usarlos. Un icono de cadena aparecerá en el Outliner indicando que esos objetos/escenas son vinculados, no locales. Si el archivo externo cambia, una recarga actualizará los datos linkeados en la siguiente ejecución del node tree (o reabriendo el archivo actual)
-docs.blender.org
-.
-Create List: Este nodo permite construir manualmente una lista de datablocks a partir de entradas individuales. Por ejemplo, podría servir para combinar elementos de distintas fuentes en una sola lista. Tendrá múltiples entradas del mismo tipo de dato (por ejemplo entradas de tipo Object) y una salida que es una lista de ese tipo (lista de Object). En Blender existe el patrón de nodos con número variable de entradas, como Join Geometry, donde el usuario puede agregar entradas extra. Implementaremos comportamiento similar: inicialmente el nodo puede tener 2 entradas, y mediante un botón "+" en el nodo, añadir más sockets (esto se logra modificando la lista de sockets en draw_buttons o mediante la propiedad NodeSocketInterface en 4.x). Internamente, la ejecución del nodo simplemente tomará las referencias de todos los sockets de entrada (ignorando las no conectadas o vacías) y creará una nueva lista agregándolas en orden. Este nodo es tipado: es decir, habrá un Create List específico para cada tipo de elemento que necesitemos (Create List (Object), Create List (Scene), etc.), a menos que implementemos un genérico más complejo. En MVP se pueden implementar uno o dos tipos según se requiera.
-Get Item by Name: Nodo para extraer de una lista un elemento cuyo nombre coincida con un string dado. Se usará típicamente después de Read Blend File o Create List para buscar un datablock específico dentro de la lista. Por ejemplo, podríamos leer todas las escenas de un archivo externo y luego con Get Item by Name (Scene) buscar la escena llamada "TemplateScene". Este nodo tendría:
-Entradas: una lista de cierto tipo (por ejemplo lista de Scene) y un nombre (string).
-Salida: un único elemento del tipo (Scene en este caso) que corresponde al elemento de la lista cuyo .name coincida con el string, o quizás None/vacio si no se encuentra.
-Implementación: recorrer la lista de objetos Blender proporcionada y retornar el primero cuyo elem.name == nombre.
-Tipado dinámico: Una cuestión de diseño es si Get Item by Name debería ser un nodo genérico (capaz de operar sobre cualquier lista de ID) o si habrá variantes específicas (Get Scene by Name, Get Object by Name, etc.). Dado que en Python podemos obtener el tipo de los elementos de la lista, en teoría un solo nodo podría manejar múltiples tipos. Sin embargo, en Blender los sockets de salida deben tener un tipo fijo definido por la clase de nodo. Por simplicidad, podemos registrar nodos separados por tipo, o usar plantillas genéricas con metaprogramación. En el documento lo trataremos como nodos específicos por tipo para mayor claridad del desarrollador.
-Set World to Scene: Este es un nodo de acción (output) que en el MVP ejemplifica la modificación de datos destino. Toma un World y lo asigna a una Scene. Sus sockets típicos:
-Entradas: una Scene destino (por ejemplo, la escena que queremos modificar) y un World.
-Salida: podríamos no tener salida (o potencialmente repetir la Scene modificada como confirmación).
-Función: al ejecutarse, realizará scene.world = world. Esto cambia el entorno (environment) de la escena, lo que es un cambio visible (en el render world background por ejemplo) y demuestra cómo las modificaciones se aplican.
-Uso típico en un node tree: un posible flujo es: Group Input provee la Scene destino (quizá la escena actual), Read Blend File carga un World desde un archivo externo, Get Item by Name extrae el World llamado "HDRI_X" de la lista, y Set World to Scene conecta esa Scene y ese World, aplicando el cambio.
-Consideraciones: Este nodo efectúa una asignación directa en los datos de Blender, por lo que es un punto de salida del sistema procedural. A diferencia de otros nodos que solo preparan datos, Set World to Scene tiene un efecto colateral inmediato en la estructura de datablocks (similar a cómo en el compositor el nodo Composite establece la imagen final, o en Geometry Nodes el Group Output aplica el resultado a la geometría). En futuras extensiones podríamos tener otros nodos de acción (e.g. Add Object to Scene, Apply Material, etc.), pero todos deben seguir la regla de determinismo: no crear variaciones aleatorias ni estado acumulativo. Si se vuelve a ejecutar, simplemente reasegurarán que la Scene tenga asignado ese World (lo cual si ya estaba asignado, resulta en ningún cambio adicional).
-Además de estos nodos, el sistema contará con el nodo Group Output (salida del grupo) si la interfaz del NodeTree define salidas. En el caso de File Nodes, es posible que la salida no se use ampliamente, ya que el "efecto" deseado suele ser la acción de los nodos finales (como Set World). Sin embargo, podríamos exponer alguna salida en la interfaz para depuración o para futuros encadenamientos (por ejemplo, una salida booleana de éxito, o una lista resultante para usar en otro context). En MVP, el Group Output podría omitirse o quedar vacío. Representación visual y usabilidad: En el editor de File Nodes, estos nodos personalizados aparecerán con nombres y colores distintos para facilitar su identificación. Por ejemplo, los sockets de listas de Scene podrían tener un color azul, los de objetos verde, etc. Los nodos de acción podrían destacarse con un borde especial o un ícono (como un símbolo de “aplicar” en Set World). Se incluirán descripciones (bl_description) claras para cada nodo, dado que los desarrolladores usuarios del addon deben entender su función rápidamente. Cada nodo implementará draw_buttons si necesita UI extra (por ejemplo, Read Blend File tendría un botón o campo para escoger la ruta del archivo). En resumen, el diseño de los nodos del MVP cubre la cadena básica: entrada del contexto actual → lectura de datos externos → combinación/filtrado → aplicación a la escena destino. Esta base es análoga a un pequeño pipeline de datos, donde los nodos a la izquierda generan datos, los del medio los procesan, y los de la derecha producen efectos o resultados
-nortikin.github.io
-. Este concepto de grafo como algoritmo es central en la arquitectura nodal
-nortikin.github.io
-. (Diagrama conceptual sugerido): Un diagrama podría ilustrar un ejemplo simple: Nodo Group Input (Scene actual) conectado a Set World to Scene (como Scene destino), Nodo Read Blend File (archivo “library.blend”) sacando una lista de Worlds, conectado a un nodo Get Item by Name (“NightSky”) cuyo resultado World va al Set World to Scene. Esto mostraría cómo fluyen los datos desde la izquierda (inputs) hacia la derecha (acción final). Cada conexión lleva un tipo de dato específico (Scene, World, etc.), evitando ambigüedades.
-Modelo de Ejecución y Stack de Modificadores
-El modelo de ejecución define cómo y cuándo se calculan los node trees de File Nodes y se aplican sus efectos. A diferencia de los node trees integrados de Blender (Shader, Geometry, Compositor), nuestro NodeTree no tiene un motor de evaluación en C++; debe ser evaluado a través de Python. Por tanto, definiremos un mecanismo claro:
-Ejecución por demanda (trigger): Se escogerá un conjunto de eventos que disparen la reevaluación de los File Nodes:
-Al abrir un archivo .blend que contiene Scenes con modificadores File Nodes, el addon deberá detectar este estado (por ejemplo, en un handler load_post o scene_update_post) y ejecutar los node trees para aplicar los cambios iniciales.
-Cuando el usuario modifica algún parámetro relevante: por ejemplo, cambia la ruta en un nodo Read Blend File, cambia el nombre buscado en un Get Item by Name, o intercambia el World en un Set World to Scene, el sistema debería actualizarse. Blender no ejecuta automáticamente nodos Python, así que podemos interceptar estos cambios usando callbacks bpy.types.Node.update en cada nodo (propiedades definidas con update=...).
-Manualmente: es útil ofrecer un botón "Actualizar" en la UI del panel de File Nodes (en la Scene) para forzar la reejecución del stack completo. Así el desarrollador/usuario puede asegurarse de que los nodos están sincronizados, especialmente si los datos externos han cambiado en disco.
-Integración con Depgraph: Idealmente, podríamos aprovechar depsgraph_update_post to detect if a linked library data-block has changed (Blender 3.x introdujo bpy.types.BlendData.libraries y se pueden chequear). Sin embargo, para MVP, una recarga manual o por abrir/cambiar escena es suficiente.
-Recorrido del node tree (evaluador): La ejecución de un FileNodesTree se realiza mediante un recorrido determinístico de sus nodos. Dado que no tenemos soporte de Blender para “empezar en el Group Output y evaluar hacia atrás automáticamente” (eso ocurre solo con nodos nativos
-blender.stackexchange.com
-), implementaremos un procedimiento:
-Identificación de nodos iniciales: Podemos comenzar por nodos sin entradas (por ejemplo, Group Input, Read Blend File) ya que son fuentes de datos.
-Orden de evaluación: Una estrategia sencilla es un topological sort de nodos según las conexiones, evaluando de inputs hacia outputs (izquierda a derecha del grafo). Como precaución, hay que detectar dependencias cíclicas (en principio, no deberían existir en un uso correcto; podemos documentar que no se soportan loops en MVP).
-Evaluación nodo a nodo: Para cada nodo, se llama a su función de ejecución (que podemos implementar como un método Python, por ejemplo Node.process(context, data) o similar). Esta función:
-Lee los valores de sus sockets de entrada. Si la entrada viene conectada desde otro nodo, tomamos el valor que el nodo previo calculó. Si es una entrada de Group Input (valor externo), tomamos el valor proporcionado por la Scene/Contexto.
-Realiza la operación del nodo (por ejemplo, Read Blend File usará la ruta para linkear datos y almacenará listas; Get Item by Name buscará en la lista; Set World to Scene asignará la propiedad en la Scene).
-Asigna los resultados a sus sockets de salida, de modo que nodos dependientes puedan leerlos.
-Finalización: Continúa hasta que todos los nodos hayan sido evaluados. Es importante el manejo de nodos de acción: en el caso de Set World to Scene, la “salida” es la acción misma (efecto aplicado). Podemos considerar que el node tree completo no devuelve explícitamente un valor final (a diferencia de Geometry Nodes que devuelve geometría). En su lugar, la “aplicación” del modificador se entiende como haber ejecutado todas las acciones de salida en orden.
-Como ejemplo: Supongamos un node tree con estructura Scene (Group Input) -> Set World to Scene, y Read Blend File -> Get World by Name -> Set World to Scene. El evaluador:
-Toma la escena del Group Input (ya conocida, digamos Scene "A").
-Evalúa Read Blend File: carga las listas de objetos, escenas, etc., del archivo externo, almacenando internamente las referencias (por ejemplo, node.output_worlds = [World1, World2, ...]).
-Evalúa Get World by Name: lee la lista de worlds de la salida del nodo anterior, busca el nombre dado, pone la referencia encontrada (ej: World "NightSky") en su salida.
-Evalúa Set World to Scene: toma la Scene de Group Input (Scene "A") y el World de Get World by Name, y hace SceneA.world = NightSky. Este asignamiento cambia el world de la escena en Blender inmediatamente.
-Node tree terminado. Como efecto, la Scene "A" ahora tiene asignado el World "NightSky" (que fue linkeado desde el archivo externo).
-Apilamiento de múltiples modificadores (stack): Si la Scene tiene más de un FileNodesTree asignado (múltiples file modifiers en la lista), debemos definir cómo interactúan:
-Por defecto, se procesarán secuencialmente en el orden del stack, similar a como Blender aplica modifiers de arriba a abajo
-docs.blender.org
-. Es decir, el primer File Nodes mod se ejecuta y realiza sus cambios, luego el siguiente toma el resultado del anterior como nueva base y ejecuta sus propias operaciones, y así sucesivamente.
-Aislamiento: Cada node tree opera potencialmente sobre la misma Scene (u otros datablocks). Es importante que no haya conflictos: por ejemplo, si el Modificador1 ya asignó un World a la Scene, y el Modificador2 también lo hace, el resultado final será el del Modificador2 (último en la pila). Esto es aceptable siempre que sea intencional. Se debe advertir a los desarrolladores que el orden de la pila afecta el resultado, igual que en modifiers de objeto
-docs.blender.org
-.
-Si un node tree depende de un efecto de otro (por ejemplo, Mod1 crea una lista de objetos y Mod2 usa esa lista), actualmente no hay un canal directo de comunicación entre node trees separados. Cada NodeTree está encapsulado; sin embargo, como todos operan en los datablocks globales de Blender, uno puede crear datos que otro luego use. Por ejemplo, Mod1 podría linkear ciertos objetos de un archivo y añadirlos a una colección de la Scene, y Mod2 tomar esos objetos (porque ya están en la escena). Esto requiere cuidado pero es posible. En futuras iteraciones podríamos permitir que un FileNodesTree emita salidas que alimenten a otro, pero no es parte del MVP.
-Ejecución en cadena: Implementacionalmente, al actualizar los File Nodes, iteraremos por la colección Scene.file_node_modifiers en orden; por cada modificador activo, ejecutaremos su NodeTree. Para eficiencia, si supiéramos que un modificador no afecta a otro, podríamos paralelizar, pero no se asume tal independencia a priori (en general, ejecutar secuencialmente es más seguro para evitar race conditions Python).
-Determinismo y repetibilidad: Dado que es posible que un modificador posterior dependa de algo que hizo uno anterior, es crucial que cada ejecución del stack completo parta de un estado consistente. Una estrategia es resetear o registrar ciertos valores antes de ejecutar. Por ejemplo, podríamos almacenar el estado original de la Scene (como qué World tenía, qué colecciones u objetos originalmente) la primera vez que se añade un FileNodesTree, de modo que si se quita/desactiva el modificador podamos restaurar ese estado (similar a Apply/Remove Modifier). Esto se discute más en la sección de gestión de datablocks. En ejecución normal, sin embargo, un modificador debería leer siempre los valores actuales antes de decidir una acción. Esto garantiza que si un usuario manualmente cambió algo, el siguiente run del node tree lo detecte si es relevante (p.ej., si cambió el World manualmente y luego se ejecuta File Nodes, probablemente se sobreescribirá de nuevo según la lógica nodal, manteniendo la autoridad del sistema procedural).
-Cancelación y errores: Durante la evaluación, podrían ocurrir errores (por ejemplo, archivo .blend no encontrado, o nombre no hallado en Get Item by Name). En MVP, estos errores se pueden reportar en la consola o como mensajes en el nodo (setting node.error_message). No se implementa una recuperación sofisticada; simplemente el nodo con error podría detener la ejecución posterior o marcarse. Una mejora futura es destacar nodos problemáticos (similar a Sverchok que resalta nodos que cambiaron o fallaron
-nortikin.github.io
-). Para la ejecución determinista, cualquier error reproducible siempre ocurrirá en el mismo punto dado los mismos datos, lo cual facilita depurar.
-En síntesis, el modelo de ejecución de File Nodes recorre el grafo de nodos resolviendo los datos de izquierda a derecha y aplicando acciones al final, análogo a “ejecutar un pequeño script visual”. Cada File Modifier de la Scene actúa como un paso en un pipeline mayor (stack) y juntos producen el estado final de la escena. Este funcionamiento recuerda que los node trees son esencialmente descripciones algorítmicas que nuestro sistema interpreta para efectuar cambios
-nortikin.github.io
-. La comparación con Geometry Nodes es válida en que ambos usan nodos para describir transformaciones, pero difiere en implementación: Geometry Nodes delega la evaluación al motor de Blender, mientras File Nodes la realiza en Python, dándonos flexibilidad a costa de rendimiento y con la responsabilidad de integridad sobre nosotros. (Opcional: diagrama de flujo): Un diagrama aquí podría mostrar el flujo de evaluación: por ejemplo, un diagrama de actividad: "Inicio (trigger) -> Para cada mod en Scene: -> Evaluar NodeTree: [bucle: para cada nodo en orden topológico -> ejecutar nodo] -> Fin del NodeTree -> siguiente mod -> Fin". Esto ayudaría a visualizar la secuencia, especialmente el stack.
-Especificación de la Interfaz: Sockets, Tipos de Datos y Estructuras de Listas
-Una parte esencial de la implementación es definir claramente qué tipos de datos circulan por los sockets y cómo se representan esas listas de datablocks internamente. Esta sección detalla esas decisiones técnicas:
-Sockets personalizados para datablocks: Dado que Blender no provee NodeSockets nativos para tipos como Object, Scene, Collection, World, definiremos sockets específicos:
-FileNodesSocketScene – para referencias individuales a bpy.types.Scene. En la interfaz podrían mostrarse con el icono de escena (el mismo que en el Outliner para Scenes) para claridad.
-FileNodesSocketObject – para bpy.types.Object.
-FileNodesSocketCollection – para bpy.types.Collection.
-FileNodesSocketWorld – para bpy.types.World.
-Además, sockets para listas:
-FileNodesSocketSceneList – conteniendo una lista de escenas.
-FileNodesSocketObjectList
-FileNodesSocketCollectionList
-FileNodesSocketWorldList
-Implementación: Cada clase heredará de NodeSocket. Por ejemplo:
-python
-Copiar
-Editar
-class FileNodesSocketScene(NodeSocket):
-    bl_idname = "FileNodesSocketScene"
-    bl_label = "Scene (Socket)"
-    # Maybe specify a color
-    def draw(self, context, layout, node, text):
-        layout.label(text or "Scene", icon='SCENE_DATA')
-    def draw_color(self, context, node):
-        return (0.6, 0.9, 1.0, 0.5)  # RGBA color for scene socket
-Estas sockets pueden almacenar internamente un valor de tipo bpy.types.Scene (o None). Para ello usamos una Property, por ejemplo:
-python
-Copiar
-Editar
-value: bpy.props.PointerProperty(type=bpy.types.Scene)
-Sin embargo, hay que considerar que PointerProperty a ID custom en versiones recientes ha tenido problemas (reportes indican cambios entre Blender 4.2 y 4.3)
-blenderartists.org
-. Afortunadamente, apuntar a datablocks básicos (Scene, Object, etc., que son subclase de ID) suele funcionar bien
-blender.stackexchange.com
-. Otra opción es almacenar solo el nombre del datablock y resolverlo en tiempo de ejecución, pero eso pierde la robustez ante renombrados. Dado que los propios nodos se evalúan en vivo, podemos permitirnos guardar la referencia directa.
-Para sockets de lista, Blender no soporta directamente PointerProperty de lista; en su lugar, optamos por guardar una lista de nombres o utilizar un tipo Python list en la propia instancia Node (no en la definición de socket). Lo común en addons nodales (Animation Nodes, Sverchok) es que cada nodo tenga atributos Python para sus datos temporales, ya que durante la ejecución no estamos limitados por RNA. Por ejemplo, node.cached_objects = [obj1, obj2, ...] dentro del nodo Read Blend File. Ese cache puede luego ser leído por nodos conectados. No necesitamos exponer esa lista al RNA ni guardarla en el .blend (es calculable nuevamente).
-En resumen, las conexiones de sockets en este sistema pasarán referencias a los objetos Blender (IDs) en memoria, lo que es válido mientras esos IDs existan. Si un objeto externo fue linkeado y luego el usuario cierra el archivo externo o lo desvincula, esa referencia podría invalidarse. Pero en condiciones normales (link persistente mientras el .blend está abierto), no habrá problema.
-Interfaz del NodeTree (Group Inputs/Outputs): Como se mencionó, definiremos entradas útiles. En MVP, la entrada principal es la Scene (posiblemente la misma Scene donde se está aplicando el modificador). Esto lo podemos automatizar: por ejemplo, cuando se añade un FileNodesTree a la Scene, podríamos crear en su interfaz un socket Scene de entrada y asignarle por defecto la Scene actual. La API para esto en Blender 4.0+ sería:
-python
-Copiar
-Editar
-tree = bpy.data.node_groups.new("FileNodesTree", "FileNodesTreeType")
-tree.interface.new_socket(name="Scene", in_out='INPUT', socket_type='FileNodesSocketScene')
-b3d.interplanety.org
-. De igual forma, podríamos añadir otras entradas si deseamos, por ejemplo un Scene Destino (si quisiéramos permitir modificar una escena distinta a la que origina la ejecución). Pero quizás es redundante: normalmente la Scene de entrada es también la de destino. En caso de necesitarlo, se podría exponer como parámetro en el modificador UI (e.g. elegir qué escena afectar).
-Desde esta versión los nodos **Group Input** y **Group Output** se sincronizan automáticamente con los sockets definidos en `node_tree.interface`. Si se añade, elimina o renombra un socket de la interfaz, ambos nodos actualizan sus propios sockets para reflejar esos cambios.
-Para salidas, no es estrictamente necesario definir alguna en MVP. Si no definimos salidas, Blender puede ocultar el nodo Group Output o mostrarlo vacío. Esto no afecta la ejecución porque no dependemos de un valor de salida para nada concreto; las acciones ya ocurrieron. Sin embargo, podríamos exponer una salida booleana "Applied" o "World Set" solo para que el Group Output no esté vacío. No profundizaremos en esto, pero es una opción.
-Tipos de estructuras de listas: Las listas manejadas por los nodos son simplemente listas de Python de objetos Blender. No crearemos por ahora una clase contenedora propia (como hace Animation Nodes, que define su wrappers para listas) ya que añadirá complejidad innecesaria en MVP. Esto significa que un socket de tipo FileNodesSocketObjectList conceptualmente lleva un list[bpy.types.Object]. En la interfaz del editor de nodos, cuando un socket es de tipo lista, podemos distinguirlo quizá por el nombre ("Objects List") y tal vez un icono de lista. Blender no soporta directamente mostrar la longitud ni elementos en el socket UI, pero podríamos en la descripción/tooltip indicar qué elementos contiene tras la última ejecución.
-Conversión y restricciones de tipos: El sistema debe prevenir conexiones incompatibles. Blender hará cumplir que solo sockets del mismo bl_idname se conecten. Así, no se podrá conectar un Scene a un Object List, etc. Es labor del desarrollador del addon registrar correctamente cada NodeSocket con un idname único y usar esos tipos en los Node.bl_socket_types de inputs/outputs. Por ejemplo, definiremos en ReadBlendFile:
-python
-Copiar
-Editar
-class FNReadBlendFileNode(Node):
-    # ...
-    def init(self, context):
-        self.outputs.new('FileNodesSocketSceneList', "Scenes")
-        self.outputs.new('FileNodesSocketObjectList', "Objects")
-        self.outputs.new('FileNodesSocketCollectionList', "Collections")
-        self.outputs.new('FileNodesSocketWorldList', "Worlds")
-De este modo, el editor de nodos sabrá que solo sockets de tipo lista de mundoss se podrán enchufar a entradas que esperen lista de mundos, etc. Si se intenta una conexión indebida, Blender no la creará.
-No mezcla de diferentes contextos: Es importante notar que estos tipos corresponden a datablocks de Blender globales. No pasamos, por ejemplo, datos crudos (números, strings) entre nodos excepto en casos puntuales (e.g. el nombre string en Get Item by Name). Todo lo demás son referencias a IDs. Esto mantiene la semántica clara: el sistema opera al nivel de objetos Blender existentes. No generamos objetos nuevos fuera del contexto de Blender; cuando Read Blend File “crea” la lista de objetos, en realidad es porque detrás ya hicimos bpy.data.objects.load(...) o similar y los objetos linkeados existen en bpy.data.objects. Por lo tanto, cada elemento en una lista tiene su correspondencia en el Outliner/estructura de Blender. Esto facilita la transparencia y debug: un desarrollador puede abrir el Outliner en modo Blender File y ver los datos linkeados (marcados con el icono de cadena y la librería origen)
-docs.blender.org
-.
-Interacción con la UI de Blender (prop_search, etc.): Aunque los sockets transmitirán referencias internamente, sería conveniente permitir al usuario seleccionar ciertos datablocks en nodos. Por ejemplo, un posible mejoramiento es que en Get Item by Name en lugar de escribir el nombre manualmente, pueda desplegar una lista de nombres disponibles. Esto se puede hacer con un prop_search en draw_buttons, buscando en la lista conectada. Sin embargo, eso requiere que la lista tenga ya valores (lo que implica ejecución previa). En MVP, probablemente dejemos el nombre como campo libre (StringProperty) a introducir manualmente, y confiaremos en la consola/log para avisar si no se encontró.
-Soporte de no persistencia en sockets: Notar que almacenaremos referencias a datos linkeados que pueden no ser guardadas en el .blend (si no las hacemos fake user). Ejemplo: Read Blend File linkea mundos del archivo externo. Si el usuario guarda el .blend actual, esos mundos linkeados –al ser datos no usados directamente– podrían ser descartados a menos que:
-Se les marque Fake User, lo cual no es posible para linkeados sin edición
-docs.blender.org
- (por diseño Blender no deja fake-user en datos link).
-O que estén referenciados por algo, e.g. la Scene mundial asignado a una Scene, con lo cual tienen un usuario.
-O como sugiere la documentación, tener un custom property apuntando a ellos para mantenerlos
-docs.blender.org
-. Irónicamente, nuestra estructura nodal precisamente hace algo parecido: la NodeTree y los nodos en memoria apuntan a esos data-blocks. Sin embargo, no está claro si esas referencias Python cuentan para Blender como “uso” al guardar. Es probable que no (Blender cuenta usuarios principalmente en estructuras C).
-Por ello, la gestión de usuarios la trataremos en la siguiente sección, pero en la interfaz queremos exponer que los linkeos son temporales/procedurales. En la UI del panel podríamos mostrar una etiqueta de advertencia junto a cada modificador: "Datos externos linkeados se aplican en tiempo de ejecución y no se guardan permanentemente a menos que se apliquen.". Si el usuario desea hacer permanente algo, deberá aplicar (copiar) manualmente o en un futuro podríamos implementar un nodo “Apply Data” que convierta un enlace en datos locales.
-Resumiendo, la especificación de interfaz define un conjunto fijo de tipos de socket representando datatypes Blender básicos y sus listas. Esto garantiza que la construcción de node trees sea rígida en tipado, previniendo errores de conectar cosas incompatibles. Los desarrolladores usarán estos sockets sabiendo exactamente qué esperan (una lista de objetos, una escena, etc.). Las estructuras de lista son simplemente listas Python de IDs, manejadas internamente, lo que nos da flexibilidad máxima en Python. Mantendremos las listas ordenadas tal como Blender las entrega (por ejemplo, Scenes probablemente en orden de creación, Objects en orden de cómo se listaron al linkear). Si se requiere orden específico, se puede implementar en nodos futuros (p.ej. un nodo Sort List por nombre). Por último, conviene destacar que esta interfaz es extensible: nuevos tipos de socket pueden añadirse (por ejemplo, materiales, nodos, text data-blocks) simplemente definiendo nuevos NodeSocket y enseñando a Read Blend File a usarlos. Asimismo, se pueden agregar nodos que conviertan entre tipos (no en MVP, pero p.ej. un nodo para filtrar de una lista de objetos aquellos pertenecientes a cierta colección). La estructura planteada sienta las bases para tales ampliaciones, con el mínimo viable para MVP centrado en Scenes/Objects/Worlds.
-Gestión de Datablocks y Convivencia con la Edición Manual
-Uno de los desafíos del sistema File Nodes es manipular datablocks de Blender (escenas, objetos, etc.) de forma procedimental sin interferir negativamente con las acciones manuales del usuario. En esta sección se detallan los principios para lograr que la edición manual y el sistema nodal no se solapen en conflicto, asegurando integridad de datos y predecibilidad. No destructividad y reversibilidad: Similar a los modifiers tradicionales que son no destructivos (no modifican la geometría base a menos que se apliquen)
-docs.blender.org
-, File Nodes busca ser no destructivo sobre la estructura de la escena:
-Cuando un node tree asigna un World a una Scene (con Set World to Scene), no borra el World anterior permanentemente ni elimina su existencia; simplemente cambia la referencia. Podemos conservar el World anterior en una variable en Python (por ejemplo, prev_world = scene.world antes de asignar el nuevo) en caso que quisiéramos restaurarlo si se deshabilita el modificador. Una buena práctica es que al habilitar un FileNodesTree como modificador, el sistema almacene el estado inicial relevante. En este caso, podríamos guardar en cada item de Scene.file_node_modifiers el world original de la escena cuando se añadió el modificador que contenga un Set World. Así, si el usuario desactiva/quita ese modificador, se restaura el world original de la escena (similar a Apply vs Revert).
-Para datos linkeados (objetos, colecciones, etc.), la analogía con no destructivo es: no incorporamos esos datos definitivamente al blend hasta que el usuario decida. Es decir, si se quita el nodo o modificador que trajo un objeto externo, idealmente ese objeto linkeado ya no debería permanecer en la escena o en el archivo (salvo que otro modificador lo necesite). Esto evita “basura” de datos residuales que el usuario tendría que limpiar manualmente. Lograr esto implica que debamos rastrear qué data-blocks fueron introducidos por cada FileNodesTree. Una estrategia es mantener un set/lista de IDs linkeados por nodo (dentro del nodo Read Blend File quizás). Si el node tree se invalida o se quita, podríamos programáticamente remover esos datablocks si no están usados en ningún otro lado:
-Remover un datablock linkeado puede implicar simplemente desvincularlo de cualquier colección/escena y luego usar bpy.data.objects.remove(obj) en Python para objetos, o bpy.data.worlds.remove(world) para worlds, etc. Sin embargo, Blender solo permite eliminar datablocks que no tienen usuarios. En nuestro caso, si un World linkeado está asignado a una Scene, primero tendríamos que dejar de usarlo (ej. asignar un world distinto o None) antes de eliminarlo.
-Para MVP, podríamos simplificar: en lugar de eliminar, podríamos dejar los datos linkeados pero advertir que ya no son utilizados. Sin embargo, para no saturar la .blend con datos fantasmas, es mejor al menos removerlos de escenas/colecciones.
-Protección contra edición simultánea: Como se mencionó, los data-blocks linkeados vienen bloqueados para edición
-docs.blender.org
-. Por ejemplo, un objeto linkeado no permite mover su posición (a menos que se use Library Override, lo cual es una operación manual avanzada). Esto es beneficioso: significa que si File Nodes trajo, digamos, un objeto X desde otra librería y lo colocó en la escena, el usuario no podrá moverlo ni rotarlo directamente, evitando así cambiar algo que el sistema considera procedimental. Si el usuario desea manipularlo, tendría que hacer override, lo cual conceptualmente “rompe” la procedencia procedural y convierte ese dato en manual. Recomendación: El equipo debe documentar que los objetos/escenas importados vía File Nodes son de solo lectura salvo que el usuario decida hacer override, en cuyo caso, esos cambios manuales podrían ser sobreescritos en la siguiente ejecución del node tree (porque el node tree volverá a linkear o setear según su lógica).
-Sincronización manual vs procedimental: ¿Qué pasa si el usuario cambia manualmente algo y el node tree también lo cambia? Debemos definir prioridad:
-En general, en sistemas de nodos procedurales, se asume que el resultado del nodo tiene la última palabra mientras esté activo. Es decir, si la escena está bajo la influencia del FileNodesTree, las propiedades que ese Tree controla se recalcularán y aplicarán, sobrescribiendo ediciones manuales. Por ejemplo, si el usuario cambia el world de la escena manualmente a "World_B" pero el node tree en su próxima ejecución lo volverá a poner en "World_A" desde librería, entonces la edición manual no persistirá. Esto es consistente con modifiers: mientras un modificador está activo, deformando la geometría, no se puede editar directamente los vértices resultantes; habría que aplicar el modificador primero
-docs.blender.org
-.
-Por lo tanto, principio: Los datos controlados por File Nodes deben considerarse no editables manualmente mientras el sistema esté activo. Para cambios manuales, el usuario debería desactivar o aplicar el modificador.
-En MVP, podemos implementar una indicación visual sencilla: por ejemplo, un icono/etiqueta en la UI de la Scene que diga "File Nodes Active: la escena está siendo modificada proceduralmente". Incluso se podría listar qué propiedades están siendo afectadas (no trivial de deducir automáticamente, pero en el ejemplo, sabemos que world de la scene lo es). Esto va más hacia UX, pero es relevante para los desarrolladores que usan la herramienta, para no confundirse al ver que su cambio manual "no toma" porque el sistema lo revierte.
-Aplicación (bake) de cambios: Eventualmente, podríamos dar la opción de aplicar permanentemente los cambios de un FileNodesTree, análogo a aplicar un modifier. Aplicar significaría:
-Para un Set World to Scene, simplemente fija el World actual y luego desconecta el node tree (posiblemente restaurando referencias para que ya no se ejecute).
-Para objetos linkeados, aplicar podría significar convertir los links en datos locales (Append / Make Library Override Real). Blender permite hacer Make Library Override o Make Local a datos vinculados para que dejen de depender de la librería externa.
-Este MVP no implementará la función de aplicar automáticamente, pero es bueno delinear que el diseño la tiene en mente. Por ahora, si alguien quiere "conservar" los efectos, siempre puede dejar el node tree activo; si quiere eliminar la dependencia externa, manualmente podría reimportar o overridear los objetos externos.
-Manejo de referencias y memoria: Un problema clásico con NodeTrees custom era la gestión de referencias y usuarios
-wiki.blender.jp
-. Antiguamente, Blend4Web usaba el nombre del NodeTree para vincularlo a una Scene, sufriendo problemas cuando el nombre cambiaba
-wiki.blender.jp
-. En nuestra implementación, al usar PointerProperty en la Scene hacia el NodeTree, evitamos el uso de nombres – la referencia es directa y robusta ante renombrado de la NodeTree (el PointerProperty de tipo ID continuará apuntando al ID correcto aunque su .name cambie, igual que pasa con pointer a objetos). Sin embargo, debemos asegurarnos de registrar esa propiedad adecuadamente:
-python
-Copiar
-Editar
-Scene.file_node_modifiers = CollectionProperty(type=FileNodeModItem)
-class FileNodeModItem(PropertyGroup):
-    node_tree: PointerProperty(type=FileNodesTree)
-    # ... other fields
-Un riesgo identificado es que entre guardados del archivo, los NodeTrees custom podían perder su contenido si no tenían un usuario asignado
-wiki.blender.jp
-. Para prevenir eso, marcaremos el NodeTree con Fake User (en Python: node_tree.use_fake_user = True) al crearlo, asegurando que aunque nada lo refiera, Blender no lo elimine al cerrar
-wiki.blender.jp
-. Esto es estándar para nodos de grupo en general: Geometry Node Groups se suelen marcar fake user cuando se crean desde la UI para no perderlos si no se usan inmediatamente.
-También consideraremos marcar fake user u otra referencia a los datablocks externos linkeados:
-Como vimos, Blender no permite fake user en datos link
-docs.blender.org
-. Pero podemos utilizar la técnica del prop pointer oculto: crear un PropertyGroup en Scene o NodeTree que tenga PointerProperties a esos data-blocks, solo para incrementar su conteo de usuario. Por ejemplo:
-python
-Copiar
-Editar
-class LinkedDataReferences(PropertyGroup):
-    world: PointerProperty(type=bpy.types.World)
-    object: PointerProperty(type=bpy.types.Object)
-    # etc.
-Si guardamos en una instancia de ese PropertyGroup las referencias a todo lo linkeado, Blender podría mantenerlos. Sin embargo, dado que en MVP vamos a recalcular en cada apertura, quizás no sea necesario guardar los links; podríamos linkear fresh cada vez (lo que duplicaría potencialmente en el .blend los datos linkeados si no limpiamos los viejos; de ahí la importancia de limpieza al cierre o apertura).
-No duplicar datos accidentalmente: Si un node tree linkea el mismo archivo dos veces (por ejemplo, dos nodos Read Blend File con la misma ruta), Blender reutilizará la librería abierta internamente en vez de cargar duplicado, creo, pero generará referencias separadas a los data-blocks. Tenemos que verificar: en Blender, si linkeas la misma .blend, verás una biblioteca con su filepath en el Outliner. Linkearla de nuevo agrega usuarios pero no duplica la entrada de biblioteca, sino que reusa la existente. Sin embargo, si se linkea el mismo objeto dos veces, podrías terminar con dos objetos duplicados con ".001" en el nombre (depende de cómo se haga la llamada bpy.data.libraries.load). Para MVP, asumir que cada Read Blend File en un node tree dado se usa para fines distintos. Aun así, advertencia: conviene evitar múltiples link al mismo data-block para no tener clones. Una idea es implementar un cache global en el addon: si ya se linkeó un cierto archivo y data-block, usar ese en lugar de volverlo a linkear. Pero esto puede dejar referencias colgando si no se controla. Por simplicidad, MVP puede permitir duplicados y dejar la responsabilidad al usuario de no hacer cosas redundantes.
-Seguridad y permisos: Leer archivos .blend externos requiere que Blender permita ejecutar esa acción. Si el usuario abre un .blend con FileNodesTrees que apuntan a archivos externos, y tiene activada la opción de seguridad Trusted Source (para auto-run Python), entonces nuestro addon podrá linkear automáticamente. Si no, Blender pedirá permiso (lo mismo que ocurre con drivers Python). Debemos documentar que para el correcto funcionamiento, la sesión debe confiar en el script. Esto es típico de cualquier addon.
-Además, puede habilitarse la nueva opción **Auto Evaluate** para que los cambios en los nodos o modificadores ejecuten de inmediato el sistema. Se activa desde las preferencias del addon o en el panel de File Nodes.
-En conclusión, la gestión de datablocks en File Nodes se basa en minimizar la interferencia con la edición manual mediante:
-Uso de linking para mantener datos externos separados y no editables
-docs.blender.org
-.
-Aplicación de principios de no destrucción (no eliminar datos originales, revertir cuando corresponda, no modificar salvo con intención clara)
-docs.blender.org
-.
-Mecanismos de referencia para no perder datos necesarios (fake users para NodeTrees, referencias para externos)
-wiki.blender.jp
-docs.blender.org
-.
-Claridad al usuario/desarrollador sobre qué controla el sistema nodal y qué permanece bajo control manual.
-Este MVP establece un delicado equilibrio: el sistema nodal ofrece automatización potente, pero el usuario debe entender que, mientras esté activo, domina ciertas partes del estado del blend. Al mismo tiempo, el desarrollador del addon debe garantizar que, al desactivar o eliminar el node tree, todo quede en un estado consistente, preferiblemente restaurando condiciones anteriores para que no queden rastros inesperados. Por ejemplo, si el node tree añadió 5 objetos linkeados a la escena, al quitarlo debería opcionalmente removerlos de la escena para no dejarlos flotando. Dado el alcance del MVP, quizá la restauración automática completa no se implemente, pero se sentarán las bases: se mantendrá registro de lo hecho, de modo que en versiones posteriores se pueda completar esta funcionalidad.
-Conclusión
-El MVP de File Nodes proporciona la infraestructura fundamental para un sistema nodal orientado a archivos y datablocks en Blender 4.4+. Hemos detallado la arquitectura (nuevo NodeTree, nodos y sockets custom, integración con Scene via file modifiers), el diseño de nodos esenciales (lectura de .blend externos, manejo de listas, búsqueda por nombre, y aplicación de cambios a la escena), el modelo de ejecución determinista con un stack secuencial de modificadores, la especificación de la interfaz tipada y estructuras de datos que fluyen por el grafo, y las consideraciones críticas para gestionar los datos de manera no destructiva y sin conflictos con la edición manual. Este documento técnico debe servir como referencia viva para desarrolladores, ofreciendo una base sólida sobre la cual construir el addon. A futuro, se podrán agregar más tipos de nodos (por ejemplo, nodos para crear nuevas escenas, para importar materiales, para sincronizar animaciones, etc.), optimizar la ejecución (cachés inteligentes, evaluaciones parciales ante cambios mínimos), e integrar mejor con herramientas de Blender como el Asset Browser. Pero incluso en esta fase inicial, File Nodes apunta hacia la filosofía de Blender “Everything Nodes”, extendiendo el paradigma procedural a la gestión de múltiples archivos y escenas de forma controlada y reproducible.
+# File Nodes
+
+File Nodes es un prototipo de addon para Blender que extiende el paradigma procedural hacia la gestión de archivos y datablocks. Su objetivo es permitir flujos de trabajo nodales que lean, combinen y apliquen datos de múltiples archivos `.blend` de forma no destructiva.
+
+## Objetivos del MVP
+- Crear un nuevo `NodeTree` personalizado.
+- Implementar nodos básicos para leer y manipular datablocks.
+- Integrar una pila de *modificadores de archivo* a nivel de `Scene`.
+
+## Nodos principales
+- **Group Input**: expone datablocks del archivo actual.
+- **Read Blend File**: importa escenas, colecciones, objetos y mundos desde archivos externos.
+- **Create List** y **Get Item by Name**: operan sobre listas de datablocks.
+- **Set World to Scene**: ejemplo de nodo de acción que modifica una `Scene`.
+
+## Arquitectura general
+1. **NodeTree personalizado**: contenedor del grafo.
+2. **Nodos**: clases que heredan de `bpy.types.Node`.
+3. **Sockets**: tipos propios para listas de objetos, escenas, etc.
+4. **File Modifiers**: colección en `Scene` que permite apilar varios grafos.
+
+## Modelo de ejecución
+Los nodos se evalúan de forma determinista sin almacenar estado entre ejecuciones. Antes de calcular cada grafo se restauran los valores originales de la escena. Esto asegura que los mismos inputs producen siempre los mismos resultados.
+
+## Gestión de datablocks
+- Los datos externos se vinculan mediante *library linking* para mantener la no destructividad.
+- Se recomienda marcar los `NodeTree` con *Fake User* para no perderlos al cerrar el archivo.
+- Al desactivar un modificador se restauran los valores previos de la escena.
+
+## Requisitos
+- Blender 4.4 o superior.
+- Python 3.10 o superior.
+
+## Conclusión
+File Nodes sienta las bases para gestionar escenas y recursos de varios archivos con un enfoque nodal. Aunque este MVP es limitado, abre la puerta a expandir el concepto de **Everything Nodes** también a la organización de proyectos.
+


### PR DESCRIPTION
## Summary
- simplify README content
- add sections, lists, and requirements for readability

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_685881a23a948330affabb5a4345acf7