### PR TITLE
Fix socket insertion index

### DIFF
--- a/nodes/create_list.py
+++ b/nodes/create_list.py
@@ -111,7 +111,7 @@ class FNCreateList(Node, FNBaseNode):
             )
             self.inputs.move(
                 self.inputs.find(new_sock.name),
-                len(self.inputs) - 1
+                len(self.inputs) - 2
             )
             self.item_count += 1
             link.to_socket = new_sock


### PR DESCRIPTION
## Summary
- fix index when inserting dynamic socket in `insert_link`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858956be4308330981ff385569ae3cc