### PR TITLE
Add scene duplication for nondestructive evaluation

### DIFF
--- a/nodes/group_input.py
+++ b/nodes/group_input.py
@@ -51,7 +51,10 @@ class FNGroupInputNode(Node, FNBaseNode):
         mod = get_active_mod_item()
         for item in _interface_inputs(self.id_data):
             if item.name == "Scene":
-                outputs[item.name] = context.scene
+                if mod and getattr(mod, "eval_scene", None):
+                    outputs[item.name] = mod.eval_scene
+                else:
+                    outputs[item.name] = context.scene
             elif mod:
                 outputs[item.name] = mod.get_input_value(item.name)
             else:

--- a/nodes/link_to_collection.py
+++ b/nodes/link_to_collection.py
@@ -25,17 +25,23 @@ class FNLinkToCollection(Node, FNBaseNode):
         if collection:
             mod = get_active_mod_item()
             for obj in objects:
-                if obj and not collection.objects.get(obj.name):
-                    collection.objects.link(obj)
-                    if mod:
-                        storage = mod._ensure_storage()
-                        storage['linked_objects'].append((collection, obj))
+                if not obj:
+                    continue
+                target = obj
+                if mod:
+                    target = obj.copy()
+                    mod.eval_objects.append(target)
+                if not collection.objects.get(target.name):
+                    collection.objects.link(target)
             for child in collections:
-                if child and not collection.children.get(child.name):
-                    collection.children.link(child)
-                    if mod:
-                        storage = mod._ensure_storage()
-                        storage['linked_collections'].append((collection, child))
+                if not child:
+                    continue
+                target = child
+                if mod:
+                    target = child.copy()
+                    mod.eval_collections.append(target)
+                if not collection.children.get(target.name):
+                    collection.children.link(target)
         return {"Collection": collection}
 
 def register():

--- a/nodes/link_to_scene.py
+++ b/nodes/link_to_scene.py
@@ -28,17 +28,23 @@ class FNLinkToScene(Node, FNBaseNode):
             root = scene.collection
             mod = get_active_mod_item()
             for obj in objects:
-                if obj and not root.objects.get(obj.name):
-                    root.objects.link(obj)
-                    if mod:
-                        storage = mod._ensure_storage()
-                        storage['linked_objects'].append((root, obj))
+                if not obj:
+                    continue
+                target = obj
+                if mod:
+                    target = obj.copy()
+                    mod.eval_objects.append(target)
+                if not root.objects.get(target.name):
+                    root.objects.link(target)
             for coll in collections:
-                if coll and not root.children.get(coll.name):
-                    root.children.link(coll)
-                    if mod:
-                        storage = mod._ensure_storage()
-                        storage['linked_collections'].append((root, coll))
+                if not coll:
+                    continue
+                target = coll
+                if mod:
+                    target = coll.copy()
+                    mod.eval_collections.append(target)
+                if not root.children.get(target.name):
+                    root.children.link(target)
         return {"Scene": scene}
 
 def register():

--- a/nodes/set_world.py
+++ b/nodes/set_world.py
@@ -21,9 +21,6 @@ class FNSetWorld(Node, FNBaseNode):
         scene = inputs.get("Scene")
         world = inputs.get("World")
         if scene and world:
-            mod = get_active_mod_item()
-            if mod:
-                mod.store_original(scene, "world")
             scene.world = world
         return {"Scene": scene}
 


### PR DESCRIPTION
## Summary
- extend `FileNodeModItem` with evaluation data and helpers
- duplicate the active scene before running a modifier
- link nodes operate on copies of objects/collections
- use duplicated scene in Group Input

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68589caaef088330b28f9a498aa14838