### PR TITLE
Improve evaluation scene handling

### DIFF
--- a/nodes/set_world.py
+++ b/nodes/set_world.py
@@ -21,6 +21,9 @@ class FNSetWorld(Node, FNBaseNode):
         scene = inputs.get("Scene")
         world = inputs.get("World")
         if scene and world:
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(scene, "world")
             scene.world = world
         return {"Scene": scene}
 

--- a/operators.py
+++ b/operators.py
@@ -32,18 +32,26 @@ def auto_evaluate_if_enabled(self=None, context=None):
 ### Evaluator ###
 def evaluate_tree(context):
     global _active_mod_item
+    base_scene = context.window.scene
     count = 0
     mods = sorted(context.scene.file_node_modifiers, key=lambda m: m.stack_index)
     scene_in = context.scene
     for mod in mods:
+        try:
+            context.window.scene = base_scene
+        except Exception:
+            pass
         mod.reset_to_originals()
         if not mod.enabled:
             mod.clear_eval_data()
 
+    prev_mod = None
     for mod in mods:
         if mod.enabled and mod.node_tree:
             mod.sync_inputs()
             mod.prepare_eval_scene(scene_in)
+            if prev_mod:
+                prev_mod.clear_eval_data()
             _active_mod_item = mod
             original_scene = context.window.scene
             try:
@@ -57,9 +65,10 @@ def evaluate_tree(context):
                 pass
             _active_mod_item = None
             scene_in = mod.eval_scene
+            prev_mod = mod
             count += 1
     try:
-        context.window.scene = scene_in
+        context.window.scene = base_scene
     except Exception:
         pass
     return count


### PR DESCRIPTION
## Summary
- keep original window scene and restore after evaluation
- clear previous evaluation scenes after use
- preserve world settings by storing original values before modification

## Testing
- `python -m py_compile operators.py modifiers.py nodes/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6858f6e6b49c833092111f2fbec78e5b