### PR TITLE
Fix crash when linking to Create List node

### DIFF
--- a/nodes/create_list.py
+++ b/nodes/create_list.py
@@ -114,7 +114,7 @@ class FNCreateList(Node, FNBaseNode):
                 len(self.inputs) - 2
             )
             self.item_count += 1
-            link.to_socket = new_sock
+            self.id_data.links.new(link.from_socket, new_sock)
             self._ensure_virtual()
             return True
         return False


### PR DESCRIPTION
## Summary
- ensure `Create List` node links are created through the node tree

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858f8f189c8833087e65e661ba5fd43