### PR TITLE
Support implicit list wrapping for objects

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -76,10 +76,29 @@ def evaluate_tree(context):
 def _evaluate_tree(tree, context):
     resolved = {}
 
+    _list_to_single = {
+        'FNSocketSceneList': 'FNSocketScene',
+        'FNSocketObjectList': 'FNSocketObject',
+        'FNSocketCollectionList': 'FNSocketCollection',
+        'FNSocketWorldList': 'FNSocketWorld',
+        'FNSocketCameraList': 'FNSocketCamera',
+        'FNSocketImageList': 'FNSocketImage',
+        'FNSocketLightList': 'FNSocketLight',
+        'FNSocketMaterialList': 'FNSocketMaterial',
+        'FNSocketMeshList': 'FNSocketMesh',
+        'FNSocketNodeTreeList': 'FNSocketNodeTree',
+        'FNSocketTextList': 'FNSocketText',
+        'FNSocketWorkSpaceList': 'FNSocketWorkSpace',
+    }
+
     def eval_socket(sock):
         if sock.is_linked and sock.links:
             from_sock = sock.links[0].from_socket
-            return eval_node(from_sock.node)[from_sock.name]
+            value = eval_node(from_sock.node)[from_sock.name]
+            single = _list_to_single.get(sock.bl_idname)
+            if single and from_sock.bl_idname == single:
+                return [value] if value is not None else []
+            return value
         # Unlinked: return stored value if exists
         if hasattr(sock, 'value'):
             return sock.value


### PR DESCRIPTION
## Summary
- evaluate nodes with awareness of single vs list sockets
- when a single item socket feeds a list socket, wrap the value in a list automatically

## Testing
- `python -m py_compile operators.py sockets.py nodes/create_list.py nodes/get_item_by_index.py nodes/get_item_by_name.py nodes/input_nodes.py nodes/link_to_scene.py nodes/link_to_collection.py nodes/read_blend.py nodes/set_world.py nodes/group_input.py nodes/group_output.py tree.py ui.py menu.py modifiers.py __init__.py`
- `python -m py_compile operators.py`

------
https://chatgpt.com/codex/tasks/task_e_6858f9e575908330b7e3f9d889faa522