### PR TITLE
Update File Nodes evaluation strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ File Nodes es un prototipo de addon para Blender que extiende el paradigma proce
 4. **File Modifiers**: colección en `Scene` que permite apilar varios grafos.
 
 ## Modelo de ejecución
-Los nodos se evalúan de forma determinista sin almacenar estado entre ejecuciones. Antes de calcular cada grafo se restauran los valores originales de la escena. Esto asegura que los mismos inputs producen siempre los mismos resultados.
+Los nodos se evalúan directamente sobre la escena activa. Antes de cada ejecución los modificadores restauran los valores originales que han guardado para mantener la no destructividad. Esto asegura que los mismos inputs producen siempre los mismos resultados.
 
 ## Gestión de datablocks
 - Los datos externos se vinculan mediante *library linking* para mantener la no destructividad.
 - Se recomienda marcar los `NodeTree` con *Fake User* para no perderlos al cerrar el archivo.
 - Al desactivar un modificador se restauran los valores previos de la escena.
+- Durante la evaluación la escena se modifica en vivo pero se conservan copias internas para volver al estado previo en la siguiente ejecución.
 
 ## Requisitos
 - Blender 4.4 o superior.

--- a/design_addendum.md
+++ b/design_addendum.md
@@ -1,0 +1,3 @@
+# Addendum: Evaluación en vivo
+
+La versión actual de File Nodes modifica directamente la escena activa durante la ejecución de cada grafo. Los modificadores registran los valores originales de los datablocks que afectan y, antes de cada evaluación, restauran dicho estado para garantizar resultados deterministas. De este modo se evita duplicar escenas temporales y se mantiene la naturaleza no destructiva del flujo.

--- a/design_addendum.pdf
+++ b/design_addendum.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250623071929+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250623071929+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 347
+>>
+stream
+Gar>B9hRi.&A7a=bcqL=qeT:%VU1olV]<COahEq,A4o*-o\[9aZrN5R87m$WZC;mC?2\KH&U6+Aht6+S?j?8(D?[Acg<:9"c_[ZGSf\b&&bB)e34Tf3YT>5MZMnA0ZqTD2d>r;MZ\Q(ke_Od"nE2Ra&k:1.X<Cde"ZXNA#KFA8/r8Nbi%;e@bdLF1<#L8&`H%\Ej@<ccV@0YAgFhqk1J<b4b;;bFXo(.>am-WVPT;%QA[I('-J@j8U7b$,:Q2&@T0_gF_=7YA=f!P\;f'#,nF%fJ=I1Lpq+@lZ.Ds<E;aKMiOF0d4G&p&N5L526&r+d,Jg=MuC2QtJdet,arXEJs@?Qa0~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
+trailer
+<<
+/ID 
+[<a95e634c5f5a07e25b29fd0ac5181549><a95e634c5f5a07e25b29fd0ac5181549>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1264
+%%EOF

--- a/modifiers.py
+++ b/modifiers.py
@@ -58,33 +58,16 @@ class FileNodeModItem(PropertyGroup):
 
     # -- Evaluation copies --
     eval_scene = None
-    eval_objects = None
-    eval_collections = None
 
     def clear_eval_data(self):
         """Remove duplicated datablocks created for evaluation."""
         if getattr(self, "eval_scene", None):
-            try:
-                bpy.data.scenes.remove(self.eval_scene)
-            except Exception:
-                pass
             self.eval_scene = None
-        for attr, datablock in [("eval_objects", bpy.data.objects),
-                                ("eval_collections", bpy.data.collections)]:
-            items = getattr(self, attr, None) or []
-            for it in items:
-                try:
-                    datablock.remove(it, do_unlink=True)
-                except Exception:
-                    pass
-            setattr(self, attr, [])
 
     def prepare_eval_scene(self, scene):
         """Duplicate the given scene for evaluation."""
         self.clear_eval_data()
-        self.eval_scene = scene.copy()
-        self.eval_objects = []
-        self.eval_collections = []
+        self.eval_scene = scene
 
     # --- Non destructive storage helpers ---
     def _ensure_storage(self):
@@ -101,6 +84,12 @@ class FileNodeModItem(PropertyGroup):
         key = (data.as_pointer(), attr)
         if key not in storage:
             storage[key] = (data, getattr(data, attr))
+
+    def remember_object_link(self, collection, obj):
+        self._ensure_storage()["linked_objects"].append((collection, obj))
+
+    def remember_collection_link(self, collection, child):
+        self._ensure_storage()["linked_collections"].append((collection, child))
 
     def reset_to_originals(self):
         self.clear_eval_data()

--- a/nodes/group_input.py
+++ b/nodes/group_input.py
@@ -51,10 +51,7 @@ class FNGroupInputNode(Node, FNBaseNode):
         mod = get_active_mod_item()
         for item in _interface_inputs(self.id_data):
             if item.name == "Scene":
-                if mod and getattr(mod, "eval_scene", None):
-                    outputs[item.name] = mod.eval_scene
-                else:
-                    outputs[item.name] = context.scene
+                outputs[item.name] = context.scene
             elif mod:
                 outputs[item.name] = mod.get_input_value(item.name)
             else:

--- a/nodes/link_to_collection.py
+++ b/nodes/link_to_collection.py
@@ -27,21 +27,17 @@ class FNLinkToCollection(Node, FNBaseNode):
             for obj in objects:
                 if not obj:
                     continue
-                target = obj
-                if mod:
-                    target = obj.copy()
-                    mod.eval_objects.append(target)
-                if not collection.objects.get(target.name):
-                    collection.objects.link(target)
+                if not collection.objects.get(obj.name):
+                    collection.objects.link(obj)
+                    if mod:
+                        mod.remember_object_link(collection, obj)
             for child in collections:
                 if not child:
                     continue
-                target = child
-                if mod:
-                    target = child.copy()
-                    mod.eval_collections.append(target)
-                if not collection.children.get(target.name):
-                    collection.children.link(target)
+                if not collection.children.get(child.name):
+                    collection.children.link(child)
+                    if mod:
+                        mod.remember_collection_link(collection, child)
         return {"Collection": collection}
 
 def register():

--- a/nodes/link_to_scene.py
+++ b/nodes/link_to_scene.py
@@ -30,21 +30,17 @@ class FNLinkToScene(Node, FNBaseNode):
             for obj in objects:
                 if not obj:
                     continue
-                target = obj
-                if mod:
-                    target = obj.copy()
-                    mod.eval_objects.append(target)
-                if not root.objects.get(target.name):
-                    root.objects.link(target)
+                if not root.objects.get(obj.name):
+                    root.objects.link(obj)
+                    if mod:
+                        mod.remember_object_link(root, obj)
             for coll in collections:
                 if not coll:
                     continue
-                target = coll
-                if mod:
-                    target = coll.copy()
-                    mod.eval_collections.append(target)
-                if not root.children.get(target.name):
-                    root.children.link(target)
+                if not root.children.get(coll.name):
+                    root.children.link(coll)
+                    if mod:
+                        mod.remember_collection_link(root, coll)
         return {"Scene": scene}
 
 def register():

--- a/operators.py
+++ b/operators.py
@@ -32,45 +32,19 @@ def auto_evaluate_if_enabled(self=None, context=None):
 ### Evaluator ###
 def evaluate_tree(context):
     global _active_mod_item
-    base_scene = context.window.scene
     count = 0
     mods = sorted(context.scene.file_node_modifiers, key=lambda m: m.stack_index)
-    scene_in = context.scene
     for mod in mods:
-        try:
-            context.window.scene = base_scene
-        except Exception:
-            pass
         mod.reset_to_originals()
-        if not mod.enabled:
-            mod.clear_eval_data()
 
-    prev_mod = None
     for mod in mods:
         if mod.enabled and mod.node_tree:
             mod.sync_inputs()
-            mod.prepare_eval_scene(scene_in)
-            if prev_mod:
-                prev_mod.clear_eval_data()
+            mod.prepare_eval_scene(context.scene)
             _active_mod_item = mod
-            original_scene = context.window.scene
-            try:
-                context.window.scene = mod.eval_scene
-            except Exception:
-                pass
             _evaluate_tree(mod.node_tree, context)
-            try:
-                context.window.scene = original_scene
-            except Exception:
-                pass
             _active_mod_item = None
-            scene_in = mod.eval_scene
-            prev_mod = mod
             count += 1
-    try:
-        context.window.scene = base_scene
-    except Exception:
-        pass
     return count
 
 def _evaluate_tree(tree, context):


### PR DESCRIPTION
## Summary
- avoid duplicating scenes during evaluation
- track linked objects and collections for restoration
- link original datablocks in linking nodes
- simplify evaluation logic
- document live-scene evaluation approach and provide an addendum PDF

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858fe6b8f3883309f55d4e13fb49194