### PR TITLE
Fix ReferenceError in link nodes

### DIFF
--- a/nodes/link_to_collection.py
+++ b/nodes/link_to_collection.py
@@ -27,14 +27,22 @@ class FNLinkToCollection(Node, FNBaseNode):
             for obj in objects:
                 if not obj:
                     continue
-                if not collection.objects.get(obj.name):
+                try:
+                    name = obj.name
+                except ReferenceError:
+                    continue  # Object was removed
+                if not collection.objects.get(name):
                     collection.objects.link(obj)
                     if mod:
                         mod.remember_object_link(collection, obj)
             for child in collections:
                 if not child:
                     continue
-                if not collection.children.get(child.name):
+                try:
+                    name = child.name
+                except ReferenceError:
+                    continue  # Collection was removed
+                if not collection.children.get(name):
                     collection.children.link(child)
                     if mod:
                         mod.remember_collection_link(collection, child)

--- a/nodes/link_to_scene.py
+++ b/nodes/link_to_scene.py
@@ -30,14 +30,22 @@ class FNLinkToScene(Node, FNBaseNode):
             for obj in objects:
                 if not obj:
                     continue
-                if not root.objects.get(obj.name):
+                try:
+                    name = obj.name
+                except ReferenceError:
+                    continue  # Object was removed
+                if not root.objects.get(name):
                     root.objects.link(obj)
                     if mod:
                         mod.remember_object_link(root, obj)
             for coll in collections:
                 if not coll:
                     continue
-                if not root.children.get(coll.name):
+                try:
+                    name = coll.name
+                except ReferenceError:
+                    continue  # Collection was removed
+                if not root.children.get(name):
                     root.children.link(coll)
                     if mod:
                         mod.remember_collection_link(root, coll)


### PR DESCRIPTION
## Summary
- avoid access to removed objects and collections in `FNLinkToScene`
- handle removed datablocks in `FNLinkToCollection`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68590678a9ac8330bee3c59560a2183f