### PR TITLE
Store modifiers globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ File Nodes es un prototipo de addon para Blender que extiende el paradigma proce
 ## Objetivos del MVP
 - Crear un nuevo `NodeTree` personalizado.
 - Implementar nodos básicos para leer y manipular datablocks.
-- Integrar una pila de *modificadores de archivo* a nivel de `Scene`.
+- Integrar una pila de *modificadores de archivo* a nivel global (`bpy.data`).
 
 ## Nodos principales
 - **Group Input**: expone datablocks del archivo actual.
@@ -19,7 +19,7 @@ File Nodes es un prototipo de addon para Blender que extiende el paradigma proce
 1. **NodeTree personalizado**: contenedor del grafo.
 2. **Nodos**: clases que heredan de `bpy.types.Node`.
 3. **Sockets**: tipos propios para listas de objetos, escenas, etc.
-4. **File Modifiers**: colección en `Scene` que permite apilar varios grafos.
+4. **File Modifiers**: colección en `bpy.data` accesible desde cualquier escena.
 
 ## Modelo de ejecución
 Los nodos se evalúan directamente sobre la escena activa. Antes de cada ejecución los modificadores restauran los valores originales que han guardado para mantener la no destructividad. Esto asegura que los mismos inputs producen siempre los mismos resultados.

--- a/modifiers.py
+++ b/modifiers.py
@@ -173,6 +173,12 @@ class FileNodeModItem(PropertyGroup):
         prop = inp.prop_name()
         return getattr(inp, prop) if prop else None
 
+class FileNodesProject(PropertyGroup):
+    """Global storage for File Nodes data."""
+
+    modifiers: bpy.props.CollectionProperty(type=FileNodeModItem)
+
+
 class FILE_NODES_UL_modifiers(UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
         if self.layout_type in {'DEFAULT', 'COMPACT'}:
@@ -188,7 +194,7 @@ class FN_OT_mod_add(Operator):
     bl_label = "Add File Node Modifier"
 
     def execute(self, context):
-        mods = context.scene.file_node_modifiers
+        mods = bpy.data.file_node_modifiers.modifiers
         item = mods.add()
         tree = bpy.data.node_groups.new("File Nodes", 'FileNodesTreeType')
         tree.use_fake_user = True
@@ -215,7 +221,7 @@ class FN_OT_mod_remove(Operator):
     bl_label = "Remove File Node Modifier"
 
     def execute(self, context):
-        mods = context.scene.file_node_modifiers
+        mods = bpy.data.file_node_modifiers.modifiers
         idx = context.scene.file_node_mod_index
         if 0 <= idx < len(mods):
             mods[idx].restore_and_clear()
@@ -232,7 +238,7 @@ class FN_OT_mod_move(Operator):
     direction: bpy.props.EnumProperty(items=[('UP','Up',''),('DOWN','Down','')])
 
     def execute(self, context):
-        mods = context.scene.file_node_modifiers
+        mods = bpy.data.file_node_modifiers.modifiers
         idx = context.scene.file_node_mod_index
         if self.direction == 'UP' and idx > 0:
             mods.move(idx, idx-1)
@@ -247,6 +253,7 @@ class FN_OT_mod_move(Operator):
 classes = (
     FileNodeModInput,
     FileNodeModItem,
+    FileNodesProject,
     FILE_NODES_UL_modifiers,
     FN_OT_mod_add,
     FN_OT_mod_remove,
@@ -256,11 +263,11 @@ classes = (
 def register():
     for cls in classes:
         bpy.utils.register_class(cls)
-    bpy.types.Scene.file_node_modifiers = bpy.props.CollectionProperty(type=FileNodeModItem)
+    bpy.types.BlendData.file_node_modifiers = bpy.props.PointerProperty(type=FileNodesProject)
     bpy.types.Scene.file_node_mod_index = bpy.props.IntProperty(default=0)
 
 def unregister():
-    del bpy.types.Scene.file_node_modifiers
+    del bpy.types.BlendData.file_node_modifiers
     del bpy.types.Scene.file_node_mod_index
     for cls in reversed(classes):
         bpy.utils.unregister_class(cls)

--- a/operators.py
+++ b/operators.py
@@ -33,7 +33,7 @@ def auto_evaluate_if_enabled(self=None, context=None):
 def evaluate_tree(context):
     global _active_mod_item
     count = 0
-    mods = sorted(context.scene.file_node_modifiers, key=lambda m: m.stack_index)
+    mods = sorted(bpy.data.file_node_modifiers.modifiers, key=lambda m: m.stack_index)
     for mod in mods:
         mod.reset_to_originals()
 

--- a/ui.py
+++ b/ui.py
@@ -13,15 +13,16 @@ class FILE_NODES_PT_global(Panel):
     def draw(self, context):
         layout = self.layout
         scene = context.scene
-        layout.template_list("FILE_NODES_UL_modifiers", "", scene, "file_node_modifiers", scene, "file_node_mod_index")
+        project = bpy.data.file_node_modifiers
+        layout.template_list("FILE_NODES_UL_modifiers", "", project, "modifiers", scene, "file_node_mod_index")
         row = layout.row(align=True)
         row.operator('file_nodes.mod_add', text="", icon='ADD')
         row.operator('file_nodes.mod_remove', text="", icon='REMOVE')
         row.operator('file_nodes.mod_move', text="", icon='TRIA_UP').direction = 'UP'
         row.operator('file_nodes.mod_move', text="", icon='TRIA_DOWN').direction = 'DOWN'
 
-        if 0 <= scene.file_node_mod_index < len(scene.file_node_modifiers):
-            mod = scene.file_node_modifiers[scene.file_node_mod_index]
+        if 0 <= scene.file_node_mod_index < len(project.modifiers):
+            mod = project.modifiers[scene.file_node_mod_index]
             box = layout.box()
             for inp in mod.inputs:
                 prop = inp.prop_name()


### PR DESCRIPTION
## Summary
- create `FileNodesProject` container with a collection of `FileNodeModItem`
- register that container on `bpy.types.BlendData`
- access modifiers globally in operators and UI
- update README to mention global storage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685997dd0c6c8330aaca0c99d31d2b23