### PR TITLE
Initialize file node modifiers safely

### DIFF
--- a/modifiers.py
+++ b/modifiers.py
@@ -285,6 +285,8 @@ def register():
         bpy.utils.register_class(cls)
     bpy.types.BlendData.file_node_modifiers = bpy.props.PointerProperty(type=FileNodesProject)
     bpy.types.Scene.file_node_mod_index = bpy.props.IntProperty(default=0)
+    # Access once to ensure the property group instance is created
+    getattr(bpy.data, "file_node_modifiers")
 
 def unregister():
     del bpy.types.BlendData.file_node_modifiers

--- a/ui.py
+++ b/ui.py
@@ -13,7 +13,10 @@ class FILE_NODES_PT_global(Panel):
     def draw(self, context):
         layout = self.layout
         scene = context.scene
-        project = bpy.data.file_node_modifiers
+        project = getattr(bpy.data, "file_node_modifiers", None)
+        if not project or not hasattr(project, "modifiers"):
+            layout.label(text="File Nodes data not initialized")
+            return
         layout.template_list("FILE_NODES_UL_modifiers", "", project, "modifiers", scene, "file_node_mod_index")
         row = layout.row(align=True)
         row.operator('file_nodes.mod_add', text="", icon='ADD')


### PR DESCRIPTION
## Summary
- avoid crash when project data isn't initialized
- force creation of the global modifiers property during registration

## Testing
- `python3 -m py_compile ui.py modifiers.py __init__.py menu.py operators.py tree.py sockets.py $(find nodes -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859a39784048330afab2f2d1ced14b4