### PR TITLE
Adjust module order for registration

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -15,9 +15,9 @@ ADDON_NAME = __name__
 
 import bpy
 import importlib
-from . import tree, sockets, nodes, operators, ui, menu, modifiers
+from . import tree, sockets, nodes, operators, modifiers, ui, menu
 
-modules = [tree, sockets, nodes, operators, ui, menu, modifiers]
+modules = [tree, sockets, nodes, operators, modifiers, ui, menu]
 
 
 class FileNodesPreferences(bpy.types.AddonPreferences):


### PR DESCRIPTION
## Summary
- include `modifiers` earlier in the list of addon modules
- ensure registration occurs using the updated ordering

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859a728c3dc833087edfd0b79ea8ad6