### PR TITLE
Move addon panel to Node Editor sidebar

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,7 @@ bl_info = {
     "author": "ChatGPT (MVP generator)",
     "version": (0, 1, 0),
     "blender": (4, 4, 0),
-    "location": "Node Editor > File Nodes",
+    "location": "Node Editor > Sidebar > File Nodes",
     "description": "Prototype node-based file/scene management",
     "category": "Object",
 }

--- a/ui.py
+++ b/ui.py
@@ -6,9 +6,9 @@ from . import ADDON_NAME
 
 class FILE_NODES_PT_global(Panel):
     bl_label = "File Nodes"
-    bl_space_type = 'PROPERTIES'
-    bl_region_type = 'WINDOW'
-    bl_context = "scene"
+    bl_space_type = 'NODE_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = 'File Nodes'
 
     def draw(self, context):
         layout = self.layout


### PR DESCRIPTION
## Summary
- display the File Nodes panel inside the Node Editor sidebar
- update bl_info location string

## Testing
- `python -m py_compile ui.py __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6859a840a9bc83308b32372e41047798