### PR TITLE
Fix global storage by using NodeTree property

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ File Nodes es un prototipo de addon para Blender que extiende el paradigma proce
 1. **NodeTree personalizado**: contenedor del grafo.
 2. **Nodos**: clases que heredan de `bpy.types.Node`.
 3. **Sockets**: tipos propios para listas de objetos, escenas, etc.
-4. **File Modifiers**: colección en `bpy.data` accesible desde cualquier escena.
+4. **File Modifiers**: colección almacenada en un `NodeTree` dedicado accesible desde cualquier escena.
 
 ## Modelo de ejecución
 Los nodos se evalúan directamente sobre la escena activa. Antes de cada ejecución los modificadores restauran los valores originales que han guardado para mantener la no destructividad. Esto asegura que los mismos inputs producen siempre los mismos resultados.

--- a/operators.py
+++ b/operators.py
@@ -1,6 +1,7 @@
 
 import bpy
 from .tree import FileNodesTree
+from .modifiers import get_project
 from bpy.types import Operator
 from collections import deque
 from types import SimpleNamespace
@@ -34,7 +35,7 @@ def auto_evaluate_if_enabled(self=None, context=None):
 def evaluate_tree(context):
     global _active_mod_item
     count = 0
-    mods = sorted(bpy.data.file_node_modifiers.modifiers, key=lambda m: m.stack_index)
+    mods = sorted(get_project().modifiers, key=lambda m: m.stack_index)
     for mod in mods:
         mod.reset_to_originals()
 

--- a/ui.py
+++ b/ui.py
@@ -1,7 +1,7 @@
 
 import bpy
 from bpy.types import Panel
-from .modifiers import FILE_NODES_UL_modifiers, FileNodeModItem
+from .modifiers import FILE_NODES_UL_modifiers, FileNodeModItem, get_project
 from . import ADDON_NAME
 
 class FILE_NODES_PT_global(Panel):
@@ -13,7 +13,7 @@ class FILE_NODES_PT_global(Panel):
     def draw(self, context):
         layout = self.layout
         scene = context.scene
-        project = getattr(bpy.data, "file_node_modifiers", None)
+        project = get_project()
         if not project or not hasattr(project, "modifiers"):
             layout.label(text="File Nodes data not initialized")
             return


### PR DESCRIPTION
## Summary
- keep global data in a dedicated NodeTree instead of `bpy.data`
- reference the new storage through helper `get_project`
- update UI and operators to use `get_project`
- document the storage location

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6859aec2b95c8330a5efc822a11e857c