### PR TITLE
Fix circular import in addon

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -1,7 +1,6 @@
 
 import bpy
 from .tree import FileNodesTree
-from .modifiers import get_project
 from bpy.types import Operator
 from collections import deque
 from types import SimpleNamespace
@@ -33,6 +32,7 @@ def auto_evaluate_if_enabled(self=None, context=None):
 
 ### Evaluator ###
 def evaluate_tree(context):
+    from .modifiers import get_project
     global _active_mod_item
     count = 0
     mods = sorted(get_project().modifiers, key=lambda m: m.stack_index)


### PR DESCRIPTION
## Summary
- resolve ImportError caused by cross imports
- lazy import `get_project` inside `evaluate_tree`

## Testing
- `python -m py_compile *.py nodes/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6859b114dc0c8330851105d538b49e8b