### PR TITLE
Add property modification nodes

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -38,6 +38,23 @@ categories = [
         NodeItem('FNLinkToCollection'),
         NodeItem('FNSetWorldNode'),
     ]),
+    NodeCategory('FILE_NODES_PROPERTIES', 'Properties', items=[
+        NodeItem('FNSetRenderEngine'),
+        NodeItem('FNCyclesSceneProps'),
+        NodeItem('FNEeveeSceneProps'),
+        NodeItem('FNWorkbenchSceneProps'),
+        NodeItem('FNOutputProps'),
+        NodeItem('FNSceneProps'),
+        NodeItem('FNObjectProps'),
+        NodeItem('FNCyclesObjectProps'),
+        NodeItem('FNEeveeObjectProps'),
+        NodeItem('FNCollectionProps'),
+        NodeItem('FNWorldProps'),
+        NodeItem('FNCameraProps'),
+        NodeItem('FNLightProps'),
+        NodeItem('FNMeshProps'),
+        NodeItem('FNMaterialProps'),
+    ]),
 ]
 
 def register():

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -5,13 +5,21 @@ import bpy, importlib
 from . import (
     read_blend, create_list, get_item_by_name, get_item_by_index,
     link_to_scene, link_to_collection, set_world, group_input, group_output,
-    input_nodes
+    input_nodes,
+    set_render_engine, cycles_scene_props, eevee_scene_props,
+    workbench_scene_props, output_props, scene_props, object_props,
+    cycles_object_props, eevee_object_props, collection_props,
+    world_props, camera_props, light_props, mesh_props, material_props,
 )
 
 _modules = [
     read_blend, create_list, get_item_by_name, get_item_by_index,
     link_to_scene, link_to_collection, set_world, group_input, group_output,
-    input_nodes
+    input_nodes,
+    set_render_engine, cycles_scene_props, eevee_scene_props,
+    workbench_scene_props, output_props, scene_props, object_props,
+    cycles_object_props, eevee_object_props, collection_props,
+    world_props, camera_props, light_props, mesh_props, material_props,
 ]
 
 def register():

--- a/nodes/camera_props.py
+++ b/nodes/camera_props.py
@@ -1,0 +1,48 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..sockets import FNSocketCamera
+from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+
+
+class FNCameraProps(Node, FNBaseNode):
+    bl_idname = "FNCameraProps"
+    bl_label = "Camera Properties"
+
+    lens: bpy.props.FloatProperty(
+        name="Focal Length",
+        default=50.0,
+        min=1.0,
+        update=auto_evaluate_if_enabled,
+    )
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketCamera', "Camera")
+        self.outputs.new('FNSocketCamera', "Camera")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "lens", text="Focal Length")
+
+    def process(self, context, inputs):
+        cam = inputs.get("Camera")
+        if cam:
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(cam, "lens")
+            try:
+                cam.lens = self.lens
+            except Exception:
+                pass
+        return {"Camera": cam}
+
+
+def register():
+    bpy.utils.register_class(FNCameraProps)
+
+def unregister():
+    bpy.utils.unregister_class(FNCameraProps)

--- a/nodes/collection_props.py
+++ b/nodes/collection_props.py
@@ -1,0 +1,46 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..sockets import FNSocketCollection
+from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+
+
+class FNCollectionProps(Node, FNBaseNode):
+    bl_idname = "FNCollectionProps"
+    bl_label = "Collection Properties"
+
+    hide_viewport: bpy.props.BoolProperty(
+        name="Hide Viewport",
+        update=auto_evaluate_if_enabled,
+    )
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketCollection', "Collection")
+        self.outputs.new('FNSocketCollection', "Collection")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "hide_viewport", text="Hide Viewport")
+
+    def process(self, context, inputs):
+        coll = inputs.get("Collection")
+        if coll:
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(coll, "hide_viewport")
+            try:
+                coll.hide_viewport = self.hide_viewport
+            except Exception:
+                pass
+        return {"Collection": coll}
+
+
+def register():
+    bpy.utils.register_class(FNCollectionProps)
+
+def unregister():
+    bpy.utils.unregister_class(FNCollectionProps)

--- a/nodes/cycles_object_props.py
+++ b/nodes/cycles_object_props.py
@@ -1,0 +1,46 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..sockets import FNSocketObject
+from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+
+
+class FNCyclesObjectProps(Node, FNBaseNode):
+    bl_idname = "FNCyclesObjectProps"
+    bl_label = "Cycles Object Properties"
+
+    is_holdout: bpy.props.BoolProperty(
+        name="Holdout",
+        update=auto_evaluate_if_enabled,
+    )
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketObject', "Object")
+        self.outputs.new('FNSocketObject', "Object")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "is_holdout", text="Holdout")
+
+    def process(self, context, inputs):
+        obj = inputs.get("Object")
+        if obj:
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(obj, "is_holdout")
+            try:
+                obj.is_holdout = self.is_holdout
+            except Exception:
+                pass
+        return {"Object": obj}
+
+
+def register():
+    bpy.utils.register_class(FNCyclesObjectProps)
+
+def unregister():
+    bpy.utils.unregister_class(FNCyclesObjectProps)

--- a/nodes/cycles_scene_props.py
+++ b/nodes/cycles_scene_props.py
@@ -1,0 +1,48 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..sockets import FNSocketScene
+from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+
+
+class FNCyclesSceneProps(Node, FNBaseNode):
+    bl_idname = "FNCyclesSceneProps"
+    bl_label = "Cycles Scene Properties"
+
+    samples: bpy.props.IntProperty(
+        name="Samples",
+        default=64,
+        min=1,
+        update=auto_evaluate_if_enabled,
+    )
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketScene', "Scene")
+        self.outputs.new('FNSocketScene', "Scene")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "samples", text="Samples")
+
+    def process(self, context, inputs):
+        scene = inputs.get("Scene")
+        if scene and hasattr(scene, "cycles"):
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(scene.cycles, "samples")
+            try:
+                scene.cycles.samples = self.samples
+            except Exception:
+                pass
+        return {"Scene": scene}
+
+
+def register():
+    bpy.utils.register_class(FNCyclesSceneProps)
+
+def unregister():
+    bpy.utils.unregister_class(FNCyclesSceneProps)

--- a/nodes/eevee_object_props.py
+++ b/nodes/eevee_object_props.py
@@ -1,0 +1,46 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..sockets import FNSocketObject
+from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+
+
+class FNEeveeObjectProps(Node, FNBaseNode):
+    bl_idname = "FNEeveeObjectProps"
+    bl_label = "Eevee Object Properties"
+
+    visible_shadow: bpy.props.BoolProperty(
+        name="Visible Shadow",
+        update=auto_evaluate_if_enabled,
+    )
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketObject', "Object")
+        self.outputs.new('FNSocketObject', "Object")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "visible_shadow", text="Visible Shadow")
+
+    def process(self, context, inputs):
+        obj = inputs.get("Object")
+        if obj:
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(obj, "visible_shadow")
+            try:
+                obj.visible_shadow = self.visible_shadow
+            except Exception:
+                pass
+        return {"Object": obj}
+
+
+def register():
+    bpy.utils.register_class(FNEeveeObjectProps)
+
+def unregister():
+    bpy.utils.unregister_class(FNEeveeObjectProps)

--- a/nodes/eevee_scene_props.py
+++ b/nodes/eevee_scene_props.py
@@ -1,0 +1,48 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..sockets import FNSocketScene
+from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+
+
+class FNEeveeSceneProps(Node, FNBaseNode):
+    bl_idname = "FNEeveeSceneProps"
+    bl_label = "Eevee Scene Properties"
+
+    samples: bpy.props.IntProperty(
+        name="Samples",
+        default=64,
+        min=1,
+        update=auto_evaluate_if_enabled,
+    )
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketScene', "Scene")
+        self.outputs.new('FNSocketScene', "Scene")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "samples", text="Samples")
+
+    def process(self, context, inputs):
+        scene = inputs.get("Scene")
+        if scene and hasattr(scene, "eevee"):
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(scene.eevee, "taa_render_samples")
+            try:
+                scene.eevee.taa_render_samples = self.samples
+            except Exception:
+                pass
+        return {"Scene": scene}
+
+
+def register():
+    bpy.utils.register_class(FNEeveeSceneProps)
+
+def unregister():
+    bpy.utils.unregister_class(FNEeveeSceneProps)

--- a/nodes/light_props.py
+++ b/nodes/light_props.py
@@ -1,0 +1,48 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..sockets import FNSocketLight
+from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+
+
+class FNLightProps(Node, FNBaseNode):
+    bl_idname = "FNLightProps"
+    bl_label = "Light Properties"
+
+    energy: bpy.props.FloatProperty(
+        name="Energy",
+        default=10.0,
+        min=0.0,
+        update=auto_evaluate_if_enabled,
+    )
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketLight', "Light")
+        self.outputs.new('FNSocketLight', "Light")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "energy", text="Energy")
+
+    def process(self, context, inputs):
+        light = inputs.get("Light")
+        if light:
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(light, "energy")
+            try:
+                light.energy = self.energy
+            except Exception:
+                pass
+        return {"Light": light}
+
+
+def register():
+    bpy.utils.register_class(FNLightProps)
+
+def unregister():
+    bpy.utils.unregister_class(FNLightProps)

--- a/nodes/material_props.py
+++ b/nodes/material_props.py
@@ -1,0 +1,47 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..sockets import FNSocketMaterial
+from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+
+
+class FNMaterialProps(Node, FNBaseNode):
+    bl_idname = "FNMaterialProps"
+    bl_label = "Material Properties"
+
+    use_nodes: bpy.props.BoolProperty(
+        name="Use Nodes",
+        default=True,
+        update=auto_evaluate_if_enabled,
+    )
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketMaterial', "Material")
+        self.outputs.new('FNSocketMaterial', "Material")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "use_nodes", text="Use Nodes")
+
+    def process(self, context, inputs):
+        mat = inputs.get("Material")
+        if mat:
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(mat, "use_nodes")
+            try:
+                mat.use_nodes = self.use_nodes
+            except Exception:
+                pass
+        return {"Material": mat}
+
+
+def register():
+    bpy.utils.register_class(FNMaterialProps)
+
+def unregister():
+    bpy.utils.unregister_class(FNMaterialProps)

--- a/nodes/mesh_props.py
+++ b/nodes/mesh_props.py
@@ -1,0 +1,46 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..sockets import FNSocketMesh
+from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+
+
+class FNMeshProps(Node, FNBaseNode):
+    bl_idname = "FNMeshProps"
+    bl_label = "Mesh Properties"
+
+    use_auto_smooth: bpy.props.BoolProperty(
+        name="Auto Smooth",
+        update=auto_evaluate_if_enabled,
+    )
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketMesh', "Mesh")
+        self.outputs.new('FNSocketMesh', "Mesh")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "use_auto_smooth", text="Auto Smooth")
+
+    def process(self, context, inputs):
+        mesh = inputs.get("Mesh")
+        if mesh:
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(mesh, "use_auto_smooth")
+            try:
+                mesh.use_auto_smooth = self.use_auto_smooth
+            except Exception:
+                pass
+        return {"Mesh": mesh}
+
+
+def register():
+    bpy.utils.register_class(FNMeshProps)
+
+def unregister():
+    bpy.utils.unregister_class(FNMeshProps)

--- a/nodes/object_props.py
+++ b/nodes/object_props.py
@@ -1,0 +1,53 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..sockets import FNSocketObject
+from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+
+
+class FNObjectProps(Node, FNBaseNode):
+    bl_idname = "FNObjectProps"
+    bl_label = "Object Properties"
+
+    hide_viewport: bpy.props.BoolProperty(
+        name="Hide Viewport",
+        update=auto_evaluate_if_enabled,
+    )
+    hide_render: bpy.props.BoolProperty(
+        name="Hide Render",
+        update=auto_evaluate_if_enabled,
+    )
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketObject', "Object")
+        self.outputs.new('FNSocketObject', "Object")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "hide_viewport", text="Hide Viewport")
+        layout.prop(self, "hide_render", text="Hide Render")
+
+    def process(self, context, inputs):
+        obj = inputs.get("Object")
+        if obj:
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(obj, "hide_viewport")
+                mod.store_original(obj, "hide_render")
+            try:
+                obj.hide_viewport = self.hide_viewport
+                obj.hide_render = self.hide_render
+            except Exception:
+                pass
+        return {"Object": obj}
+
+
+def register():
+    bpy.utils.register_class(FNObjectProps)
+
+def unregister():
+    bpy.utils.unregister_class(FNObjectProps)

--- a/nodes/output_props.py
+++ b/nodes/output_props.py
@@ -1,0 +1,57 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..sockets import FNSocketScene
+from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+
+
+class FNOutputProps(Node, FNBaseNode):
+    bl_idname = "FNOutputProps"
+    bl_label = "Output Properties"
+
+    resolution_x: bpy.props.IntProperty(
+        name="Resolution X",
+        default=1920,
+        min=1,
+        update=auto_evaluate_if_enabled,
+    )
+    resolution_y: bpy.props.IntProperty(
+        name="Resolution Y",
+        default=1080,
+        min=1,
+        update=auto_evaluate_if_enabled,
+    )
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketScene', "Scene")
+        self.outputs.new('FNSocketScene', "Scene")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "resolution_x", text="Res X")
+        layout.prop(self, "resolution_y", text="Res Y")
+
+    def process(self, context, inputs):
+        scene = inputs.get("Scene")
+        if scene:
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(scene.render, "resolution_x")
+                mod.store_original(scene.render, "resolution_y")
+            try:
+                scene.render.resolution_x = self.resolution_x
+                scene.render.resolution_y = self.resolution_y
+            except Exception:
+                pass
+        return {"Scene": scene}
+
+
+def register():
+    bpy.utils.register_class(FNOutputProps)
+
+def unregister():
+    bpy.utils.unregister_class(FNOutputProps)

--- a/nodes/scene_props.py
+++ b/nodes/scene_props.py
@@ -1,0 +1,55 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..sockets import FNSocketScene
+from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+
+
+class FNSceneProps(Node, FNBaseNode):
+    bl_idname = "FNSceneProps"
+    bl_label = "Scene Properties"
+
+    frame_start: bpy.props.IntProperty(
+        name="Start Frame",
+        default=1,
+        update=auto_evaluate_if_enabled,
+    )
+    frame_end: bpy.props.IntProperty(
+        name="End Frame",
+        default=250,
+        update=auto_evaluate_if_enabled,
+    )
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketScene', "Scene")
+        self.outputs.new('FNSocketScene', "Scene")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "frame_start", text="Start")
+        layout.prop(self, "frame_end", text="End")
+
+    def process(self, context, inputs):
+        scene = inputs.get("Scene")
+        if scene:
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(scene, "frame_start")
+                mod.store_original(scene, "frame_end")
+            try:
+                scene.frame_start = self.frame_start
+                scene.frame_end = self.frame_end
+            except Exception:
+                pass
+        return {"Scene": scene}
+
+
+def register():
+    bpy.utils.register_class(FNSceneProps)
+
+def unregister():
+    bpy.utils.unregister_class(FNSceneProps)

--- a/nodes/set_render_engine.py
+++ b/nodes/set_render_engine.py
@@ -1,0 +1,52 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..sockets import FNSocketScene
+from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+
+
+class FNSetRenderEngine(Node, FNBaseNode):
+    bl_idname = "FNSetRenderEngine"
+    bl_label = "Set Render Engine"
+
+    engine: bpy.props.EnumProperty(
+        name="Engine",
+        items=[
+            ("BLENDER_EEVEE", "Eevee", ""),
+            ("CYCLES", "Cycles", ""),
+            ("BLENDER_WORKBENCH", "Workbench", ""),
+        ],
+        default="BLENDER_EEVEE",
+        update=auto_evaluate_if_enabled,
+    )
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketScene', "Scene")
+        self.outputs.new('FNSocketScene', "Scene")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "engine", text="Engine")
+
+    def process(self, context, inputs):
+        scene = inputs.get("Scene")
+        if scene:
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(scene.render, "engine")
+            try:
+                scene.render.engine = self.engine
+            except Exception:
+                pass
+        return {"Scene": scene}
+
+
+def register():
+    bpy.utils.register_class(FNSetRenderEngine)
+
+def unregister():
+    bpy.utils.unregister_class(FNSetRenderEngine)

--- a/nodes/workbench_scene_props.py
+++ b/nodes/workbench_scene_props.py
@@ -1,0 +1,49 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..sockets import FNSocketScene
+from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+
+
+class FNWorkbenchSceneProps(Node, FNBaseNode):
+    bl_idname = "FNWorkbenchSceneProps"
+    bl_label = "Workbench Scene Properties"
+
+    aa_samples: bpy.props.IntProperty(
+        name="AA Samples",
+        default=16,
+        min=1,
+        update=auto_evaluate_if_enabled,
+    )
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketScene', "Scene")
+        self.outputs.new('FNSocketScene', "Scene")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "aa_samples", text="AA Samples")
+
+    def process(self, context, inputs):
+        scene = inputs.get("Scene")
+        if scene and hasattr(scene, "display"):
+            mod = get_active_mod_item()
+            if mod and hasattr(scene.display, 'render_aa'):
+                mod.store_original(scene.display, 'render_aa')
+            try:
+                if hasattr(scene.display, 'render_aa'):
+                    scene.display.render_aa = self.aa_samples
+            except Exception:
+                pass
+        return {"Scene": scene}
+
+
+def register():
+    bpy.utils.register_class(FNWorkbenchSceneProps)
+
+def unregister():
+    bpy.utils.unregister_class(FNWorkbenchSceneProps)

--- a/nodes/world_props.py
+++ b/nodes/world_props.py
@@ -1,0 +1,47 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..sockets import FNSocketWorld
+from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+
+
+class FNWorldProps(Node, FNBaseNode):
+    bl_idname = "FNWorldProps"
+    bl_label = "World Properties"
+
+    use_nodes: bpy.props.BoolProperty(
+        name="Use Nodes",
+        default=True,
+        update=auto_evaluate_if_enabled,
+    )
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketWorld', "World")
+        self.outputs.new('FNSocketWorld', "World")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "use_nodes", text="Use Nodes")
+
+    def process(self, context, inputs):
+        world = inputs.get("World")
+        if world:
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(world, "use_nodes")
+            try:
+                world.use_nodes = self.use_nodes
+            except Exception:
+                pass
+        return {"World": world}
+
+
+def register():
+    bpy.utils.register_class(FNWorldProps)
+
+def unregister():
+    bpy.utils.unregister_class(FNWorldProps)


### PR DESCRIPTION
## Summary
- add a suite of nodes for setting datablock properties (scene, object, etc.)
- register the new nodes and expose them in a new **Properties** node category

## Testing
- `python -m py_compile menu.py nodes/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6859d1d317e88330ae23c057e4486fec