### PR TITLE
Enable socket inputs for property nodes

### DIFF
--- a/nodes/camera_props.py
+++ b/nodes/camera_props.py
@@ -2,20 +2,14 @@ import bpy
 from bpy.types import Node
 
 from .base import FNBaseNode
-from ..sockets import FNSocketCamera
-from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+from ..sockets import FNSocketCamera, FNSocketFloat
+from ..operators import get_active_mod_item
 
 
 class FNCameraProps(Node, FNBaseNode):
     bl_idname = "FNCameraProps"
     bl_label = "Camera Properties"
 
-    lens: bpy.props.FloatProperty(
-        name="Focal Length",
-        default=50.0,
-        min=1.0,
-        update=auto_evaluate_if_enabled,
-    )
 
     @classmethod
     def poll(cls, ntree):
@@ -23,19 +17,19 @@ class FNCameraProps(Node, FNBaseNode):
 
     def init(self, context):
         self.inputs.new('FNSocketCamera', "Camera")
+        sock = self.inputs.new('FNSocketFloat', "Focal Length")
+        sock.value = 50.0
         self.outputs.new('FNSocketCamera', "Camera")
-
-    def draw_buttons(self, context, layout):
-        layout.prop(self, "lens", text="Focal Length")
 
     def process(self, context, inputs):
         cam = inputs.get("Camera")
         if cam:
+            lens = inputs.get("Focal Length")
             mod = get_active_mod_item()
             if mod:
                 mod.store_original(cam, "lens")
             try:
-                cam.lens = self.lens
+                cam.lens = lens
             except Exception:
                 pass
         return {"Camera": cam}

--- a/nodes/collection_props.py
+++ b/nodes/collection_props.py
@@ -2,18 +2,14 @@ import bpy
 from bpy.types import Node
 
 from .base import FNBaseNode
-from ..sockets import FNSocketCollection
-from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+from ..sockets import FNSocketCollection, FNSocketBool
+from ..operators import get_active_mod_item
 
 
 class FNCollectionProps(Node, FNBaseNode):
     bl_idname = "FNCollectionProps"
     bl_label = "Collection Properties"
 
-    hide_viewport: bpy.props.BoolProperty(
-        name="Hide Viewport",
-        update=auto_evaluate_if_enabled,
-    )
 
     @classmethod
     def poll(cls, ntree):
@@ -21,19 +17,19 @@ class FNCollectionProps(Node, FNBaseNode):
 
     def init(self, context):
         self.inputs.new('FNSocketCollection', "Collection")
+        sock = self.inputs.new('FNSocketBool', "Hide Viewport")
+        sock.value = False
         self.outputs.new('FNSocketCollection', "Collection")
-
-    def draw_buttons(self, context, layout):
-        layout.prop(self, "hide_viewport", text="Hide Viewport")
 
     def process(self, context, inputs):
         coll = inputs.get("Collection")
         if coll:
+            hide_vp = inputs.get("Hide Viewport")
             mod = get_active_mod_item()
             if mod:
                 mod.store_original(coll, "hide_viewport")
             try:
-                coll.hide_viewport = self.hide_viewport
+                coll.hide_viewport = hide_vp
             except Exception:
                 pass
         return {"Collection": coll}

--- a/nodes/cycles_object_props.py
+++ b/nodes/cycles_object_props.py
@@ -2,18 +2,14 @@ import bpy
 from bpy.types import Node
 
 from .base import FNBaseNode
-from ..sockets import FNSocketObject
-from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+from ..sockets import FNSocketObject, FNSocketBool
+from ..operators import get_active_mod_item
 
 
 class FNCyclesObjectProps(Node, FNBaseNode):
     bl_idname = "FNCyclesObjectProps"
     bl_label = "Cycles Object Properties"
 
-    is_holdout: bpy.props.BoolProperty(
-        name="Holdout",
-        update=auto_evaluate_if_enabled,
-    )
 
     @classmethod
     def poll(cls, ntree):
@@ -21,19 +17,19 @@ class FNCyclesObjectProps(Node, FNBaseNode):
 
     def init(self, context):
         self.inputs.new('FNSocketObject', "Object")
+        sock = self.inputs.new('FNSocketBool', "Holdout")
+        sock.value = False
         self.outputs.new('FNSocketObject', "Object")
-
-    def draw_buttons(self, context, layout):
-        layout.prop(self, "is_holdout", text="Holdout")
 
     def process(self, context, inputs):
         obj = inputs.get("Object")
         if obj:
+            holdout = inputs.get("Holdout")
             mod = get_active_mod_item()
             if mod:
                 mod.store_original(obj, "is_holdout")
             try:
-                obj.is_holdout = self.is_holdout
+                obj.is_holdout = holdout
             except Exception:
                 pass
         return {"Object": obj}

--- a/nodes/cycles_scene_props.py
+++ b/nodes/cycles_scene_props.py
@@ -2,20 +2,14 @@ import bpy
 from bpy.types import Node
 
 from .base import FNBaseNode
-from ..sockets import FNSocketScene
-from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+from ..sockets import FNSocketScene, FNSocketInt
+from ..operators import get_active_mod_item
 
 
 class FNCyclesSceneProps(Node, FNBaseNode):
     bl_idname = "FNCyclesSceneProps"
     bl_label = "Cycles Scene Properties"
 
-    samples: bpy.props.IntProperty(
-        name="Samples",
-        default=64,
-        min=1,
-        update=auto_evaluate_if_enabled,
-    )
 
     @classmethod
     def poll(cls, ntree):
@@ -23,19 +17,19 @@ class FNCyclesSceneProps(Node, FNBaseNode):
 
     def init(self, context):
         self.inputs.new('FNSocketScene', "Scene")
+        sock = self.inputs.new('FNSocketInt', "Samples")
+        sock.value = 64
         self.outputs.new('FNSocketScene', "Scene")
-
-    def draw_buttons(self, context, layout):
-        layout.prop(self, "samples", text="Samples")
 
     def process(self, context, inputs):
         scene = inputs.get("Scene")
         if scene and hasattr(scene, "cycles"):
+            samples = inputs.get("Samples")
             mod = get_active_mod_item()
             if mod:
                 mod.store_original(scene.cycles, "samples")
             try:
-                scene.cycles.samples = self.samples
+                scene.cycles.samples = samples
             except Exception:
                 pass
         return {"Scene": scene}

--- a/nodes/eevee_object_props.py
+++ b/nodes/eevee_object_props.py
@@ -2,18 +2,14 @@ import bpy
 from bpy.types import Node
 
 from .base import FNBaseNode
-from ..sockets import FNSocketObject
-from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+from ..sockets import FNSocketObject, FNSocketBool
+from ..operators import get_active_mod_item
 
 
 class FNEeveeObjectProps(Node, FNBaseNode):
     bl_idname = "FNEeveeObjectProps"
     bl_label = "Eevee Object Properties"
 
-    visible_shadow: bpy.props.BoolProperty(
-        name="Visible Shadow",
-        update=auto_evaluate_if_enabled,
-    )
 
     @classmethod
     def poll(cls, ntree):
@@ -21,19 +17,19 @@ class FNEeveeObjectProps(Node, FNBaseNode):
 
     def init(self, context):
         self.inputs.new('FNSocketObject', "Object")
+        sock = self.inputs.new('FNSocketBool', "Visible Shadow")
+        sock.value = False
         self.outputs.new('FNSocketObject', "Object")
-
-    def draw_buttons(self, context, layout):
-        layout.prop(self, "visible_shadow", text="Visible Shadow")
 
     def process(self, context, inputs):
         obj = inputs.get("Object")
         if obj:
+            shadow = inputs.get("Visible Shadow")
             mod = get_active_mod_item()
             if mod:
                 mod.store_original(obj, "visible_shadow")
             try:
-                obj.visible_shadow = self.visible_shadow
+                obj.visible_shadow = shadow
             except Exception:
                 pass
         return {"Object": obj}

--- a/nodes/eevee_scene_props.py
+++ b/nodes/eevee_scene_props.py
@@ -2,20 +2,14 @@ import bpy
 from bpy.types import Node
 
 from .base import FNBaseNode
-from ..sockets import FNSocketScene
-from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+from ..sockets import FNSocketScene, FNSocketInt
+from ..operators import get_active_mod_item
 
 
 class FNEeveeSceneProps(Node, FNBaseNode):
     bl_idname = "FNEeveeSceneProps"
     bl_label = "Eevee Scene Properties"
 
-    samples: bpy.props.IntProperty(
-        name="Samples",
-        default=64,
-        min=1,
-        update=auto_evaluate_if_enabled,
-    )
 
     @classmethod
     def poll(cls, ntree):
@@ -23,19 +17,19 @@ class FNEeveeSceneProps(Node, FNBaseNode):
 
     def init(self, context):
         self.inputs.new('FNSocketScene', "Scene")
+        sock = self.inputs.new('FNSocketInt', "Samples")
+        sock.value = 64
         self.outputs.new('FNSocketScene', "Scene")
-
-    def draw_buttons(self, context, layout):
-        layout.prop(self, "samples", text="Samples")
 
     def process(self, context, inputs):
         scene = inputs.get("Scene")
         if scene and hasattr(scene, "eevee"):
+            samples = inputs.get("Samples")
             mod = get_active_mod_item()
             if mod:
                 mod.store_original(scene.eevee, "taa_render_samples")
             try:
-                scene.eevee.taa_render_samples = self.samples
+                scene.eevee.taa_render_samples = samples
             except Exception:
                 pass
         return {"Scene": scene}

--- a/nodes/light_props.py
+++ b/nodes/light_props.py
@@ -2,20 +2,14 @@ import bpy
 from bpy.types import Node
 
 from .base import FNBaseNode
-from ..sockets import FNSocketLight
-from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+from ..sockets import FNSocketLight, FNSocketFloat
+from ..operators import get_active_mod_item
 
 
 class FNLightProps(Node, FNBaseNode):
     bl_idname = "FNLightProps"
     bl_label = "Light Properties"
 
-    energy: bpy.props.FloatProperty(
-        name="Energy",
-        default=10.0,
-        min=0.0,
-        update=auto_evaluate_if_enabled,
-    )
 
     @classmethod
     def poll(cls, ntree):
@@ -23,19 +17,19 @@ class FNLightProps(Node, FNBaseNode):
 
     def init(self, context):
         self.inputs.new('FNSocketLight', "Light")
+        sock = self.inputs.new('FNSocketFloat', "Energy")
+        sock.value = 10.0
         self.outputs.new('FNSocketLight', "Light")
-
-    def draw_buttons(self, context, layout):
-        layout.prop(self, "energy", text="Energy")
 
     def process(self, context, inputs):
         light = inputs.get("Light")
         if light:
+            energy = inputs.get("Energy")
             mod = get_active_mod_item()
             if mod:
                 mod.store_original(light, "energy")
             try:
-                light.energy = self.energy
+                light.energy = energy
             except Exception:
                 pass
         return {"Light": light}

--- a/nodes/material_props.py
+++ b/nodes/material_props.py
@@ -2,19 +2,14 @@ import bpy
 from bpy.types import Node
 
 from .base import FNBaseNode
-from ..sockets import FNSocketMaterial
-from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+from ..sockets import FNSocketMaterial, FNSocketBool
+from ..operators import get_active_mod_item
 
 
 class FNMaterialProps(Node, FNBaseNode):
     bl_idname = "FNMaterialProps"
     bl_label = "Material Properties"
 
-    use_nodes: bpy.props.BoolProperty(
-        name="Use Nodes",
-        default=True,
-        update=auto_evaluate_if_enabled,
-    )
 
     @classmethod
     def poll(cls, ntree):
@@ -22,19 +17,19 @@ class FNMaterialProps(Node, FNBaseNode):
 
     def init(self, context):
         self.inputs.new('FNSocketMaterial', "Material")
+        sock = self.inputs.new('FNSocketBool', "Use Nodes")
+        sock.value = True
         self.outputs.new('FNSocketMaterial', "Material")
-
-    def draw_buttons(self, context, layout):
-        layout.prop(self, "use_nodes", text="Use Nodes")
 
     def process(self, context, inputs):
         mat = inputs.get("Material")
         if mat:
+            use_nodes = inputs.get("Use Nodes")
             mod = get_active_mod_item()
             if mod:
                 mod.store_original(mat, "use_nodes")
             try:
-                mat.use_nodes = self.use_nodes
+                mat.use_nodes = use_nodes
             except Exception:
                 pass
         return {"Material": mat}

--- a/nodes/mesh_props.py
+++ b/nodes/mesh_props.py
@@ -2,18 +2,14 @@ import bpy
 from bpy.types import Node
 
 from .base import FNBaseNode
-from ..sockets import FNSocketMesh
-from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+from ..sockets import FNSocketMesh, FNSocketBool
+from ..operators import get_active_mod_item
 
 
 class FNMeshProps(Node, FNBaseNode):
     bl_idname = "FNMeshProps"
     bl_label = "Mesh Properties"
 
-    use_auto_smooth: bpy.props.BoolProperty(
-        name="Auto Smooth",
-        update=auto_evaluate_if_enabled,
-    )
 
     @classmethod
     def poll(cls, ntree):
@@ -21,19 +17,19 @@ class FNMeshProps(Node, FNBaseNode):
 
     def init(self, context):
         self.inputs.new('FNSocketMesh', "Mesh")
+        sock = self.inputs.new('FNSocketBool', "Auto Smooth")
+        sock.value = False
         self.outputs.new('FNSocketMesh', "Mesh")
-
-    def draw_buttons(self, context, layout):
-        layout.prop(self, "use_auto_smooth", text="Auto Smooth")
 
     def process(self, context, inputs):
         mesh = inputs.get("Mesh")
         if mesh:
+            auto = inputs.get("Auto Smooth")
             mod = get_active_mod_item()
             if mod:
                 mod.store_original(mesh, "use_auto_smooth")
             try:
-                mesh.use_auto_smooth = self.use_auto_smooth
+                mesh.use_auto_smooth = auto
             except Exception:
                 pass
         return {"Mesh": mesh}

--- a/nodes/object_props.py
+++ b/nodes/object_props.py
@@ -2,22 +2,14 @@ import bpy
 from bpy.types import Node
 
 from .base import FNBaseNode
-from ..sockets import FNSocketObject
-from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+from ..sockets import FNSocketObject, FNSocketBool
+from ..operators import get_active_mod_item
 
 
 class FNObjectProps(Node, FNBaseNode):
     bl_idname = "FNObjectProps"
     bl_label = "Object Properties"
 
-    hide_viewport: bpy.props.BoolProperty(
-        name="Hide Viewport",
-        update=auto_evaluate_if_enabled,
-    )
-    hide_render: bpy.props.BoolProperty(
-        name="Hide Render",
-        update=auto_evaluate_if_enabled,
-    )
 
     @classmethod
     def poll(cls, ntree):
@@ -25,22 +17,24 @@ class FNObjectProps(Node, FNBaseNode):
 
     def init(self, context):
         self.inputs.new('FNSocketObject', "Object")
+        sock = self.inputs.new('FNSocketBool', "Hide Viewport")
+        sock.value = False
+        sock = self.inputs.new('FNSocketBool', "Hide Render")
+        sock.value = False
         self.outputs.new('FNSocketObject', "Object")
-
-    def draw_buttons(self, context, layout):
-        layout.prop(self, "hide_viewport", text="Hide Viewport")
-        layout.prop(self, "hide_render", text="Hide Render")
 
     def process(self, context, inputs):
         obj = inputs.get("Object")
         if obj:
+            hide_vp = inputs.get("Hide Viewport")
+            hide_re = inputs.get("Hide Render")
             mod = get_active_mod_item()
             if mod:
                 mod.store_original(obj, "hide_viewport")
                 mod.store_original(obj, "hide_render")
             try:
-                obj.hide_viewport = self.hide_viewport
-                obj.hide_render = self.hide_render
+                obj.hide_viewport = hide_vp
+                obj.hide_render = hide_re
             except Exception:
                 pass
         return {"Object": obj}

--- a/nodes/output_props.py
+++ b/nodes/output_props.py
@@ -2,26 +2,14 @@ import bpy
 from bpy.types import Node
 
 from .base import FNBaseNode
-from ..sockets import FNSocketScene
-from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+from ..sockets import FNSocketScene, FNSocketInt
+from ..operators import get_active_mod_item
 
 
 class FNOutputProps(Node, FNBaseNode):
     bl_idname = "FNOutputProps"
     bl_label = "Output Properties"
 
-    resolution_x: bpy.props.IntProperty(
-        name="Resolution X",
-        default=1920,
-        min=1,
-        update=auto_evaluate_if_enabled,
-    )
-    resolution_y: bpy.props.IntProperty(
-        name="Resolution Y",
-        default=1080,
-        min=1,
-        update=auto_evaluate_if_enabled,
-    )
 
     @classmethod
     def poll(cls, ntree):
@@ -29,22 +17,24 @@ class FNOutputProps(Node, FNBaseNode):
 
     def init(self, context):
         self.inputs.new('FNSocketScene', "Scene")
+        sock = self.inputs.new('FNSocketInt', "Resolution X")
+        sock.value = 1920
+        sock = self.inputs.new('FNSocketInt', "Resolution Y")
+        sock.value = 1080
         self.outputs.new('FNSocketScene', "Scene")
-
-    def draw_buttons(self, context, layout):
-        layout.prop(self, "resolution_x", text="Res X")
-        layout.prop(self, "resolution_y", text="Res Y")
 
     def process(self, context, inputs):
         scene = inputs.get("Scene")
         if scene:
+            res_x = inputs.get("Resolution X")
+            res_y = inputs.get("Resolution Y")
             mod = get_active_mod_item()
             if mod:
                 mod.store_original(scene.render, "resolution_x")
                 mod.store_original(scene.render, "resolution_y")
             try:
-                scene.render.resolution_x = self.resolution_x
-                scene.render.resolution_y = self.resolution_y
+                scene.render.resolution_x = res_x
+                scene.render.resolution_y = res_y
             except Exception:
                 pass
         return {"Scene": scene}

--- a/nodes/scene_props.py
+++ b/nodes/scene_props.py
@@ -2,24 +2,14 @@ import bpy
 from bpy.types import Node
 
 from .base import FNBaseNode
-from ..sockets import FNSocketScene
-from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+from ..sockets import FNSocketScene, FNSocketInt
+from ..operators import get_active_mod_item
 
 
 class FNSceneProps(Node, FNBaseNode):
     bl_idname = "FNSceneProps"
     bl_label = "Scene Properties"
 
-    frame_start: bpy.props.IntProperty(
-        name="Start Frame",
-        default=1,
-        update=auto_evaluate_if_enabled,
-    )
-    frame_end: bpy.props.IntProperty(
-        name="End Frame",
-        default=250,
-        update=auto_evaluate_if_enabled,
-    )
 
     @classmethod
     def poll(cls, ntree):
@@ -27,22 +17,24 @@ class FNSceneProps(Node, FNBaseNode):
 
     def init(self, context):
         self.inputs.new('FNSocketScene', "Scene")
+        sock = self.inputs.new('FNSocketInt', "Start")
+        sock.value = 1
+        sock = self.inputs.new('FNSocketInt', "End")
+        sock.value = 250
         self.outputs.new('FNSocketScene', "Scene")
-
-    def draw_buttons(self, context, layout):
-        layout.prop(self, "frame_start", text="Start")
-        layout.prop(self, "frame_end", text="End")
 
     def process(self, context, inputs):
         scene = inputs.get("Scene")
         if scene:
+            start = inputs.get("Start")
+            end = inputs.get("End")
             mod = get_active_mod_item()
             if mod:
                 mod.store_original(scene, "frame_start")
                 mod.store_original(scene, "frame_end")
             try:
-                scene.frame_start = self.frame_start
-                scene.frame_end = self.frame_end
+                scene.frame_start = start
+                scene.frame_end = end
             except Exception:
                 pass
         return {"Scene": scene}

--- a/nodes/set_render_engine.py
+++ b/nodes/set_render_engine.py
@@ -2,24 +2,14 @@ import bpy
 from bpy.types import Node
 
 from .base import FNBaseNode
-from ..sockets import FNSocketScene
-from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+from ..sockets import FNSocketScene, FNSocketString
+from ..operators import get_active_mod_item
 
 
 class FNSetRenderEngine(Node, FNBaseNode):
     bl_idname = "FNSetRenderEngine"
     bl_label = "Set Render Engine"
 
-    engine: bpy.props.EnumProperty(
-        name="Engine",
-        items=[
-            ("BLENDER_EEVEE", "Eevee", ""),
-            ("CYCLES", "Cycles", ""),
-            ("BLENDER_WORKBENCH", "Workbench", ""),
-        ],
-        default="BLENDER_EEVEE",
-        update=auto_evaluate_if_enabled,
-    )
 
     @classmethod
     def poll(cls, ntree):
@@ -27,19 +17,19 @@ class FNSetRenderEngine(Node, FNBaseNode):
 
     def init(self, context):
         self.inputs.new('FNSocketScene', "Scene")
+        sock = self.inputs.new('FNSocketString', "Engine")
+        sock.value = "BLENDER_EEVEE"
         self.outputs.new('FNSocketScene', "Scene")
-
-    def draw_buttons(self, context, layout):
-        layout.prop(self, "engine", text="Engine")
 
     def process(self, context, inputs):
         scene = inputs.get("Scene")
         if scene:
+            engine = inputs.get("Engine")
             mod = get_active_mod_item()
             if mod:
                 mod.store_original(scene.render, "engine")
             try:
-                scene.render.engine = self.engine
+                scene.render.engine = engine
             except Exception:
                 pass
         return {"Scene": scene}

--- a/nodes/workbench_scene_props.py
+++ b/nodes/workbench_scene_props.py
@@ -2,20 +2,14 @@ import bpy
 from bpy.types import Node
 
 from .base import FNBaseNode
-from ..sockets import FNSocketScene
-from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+from ..sockets import FNSocketScene, FNSocketInt
+from ..operators import get_active_mod_item
 
 
 class FNWorkbenchSceneProps(Node, FNBaseNode):
     bl_idname = "FNWorkbenchSceneProps"
     bl_label = "Workbench Scene Properties"
 
-    aa_samples: bpy.props.IntProperty(
-        name="AA Samples",
-        default=16,
-        min=1,
-        update=auto_evaluate_if_enabled,
-    )
 
     @classmethod
     def poll(cls, ntree):
@@ -23,20 +17,20 @@ class FNWorkbenchSceneProps(Node, FNBaseNode):
 
     def init(self, context):
         self.inputs.new('FNSocketScene', "Scene")
+        sock = self.inputs.new('FNSocketInt', "AA Samples")
+        sock.value = 16
         self.outputs.new('FNSocketScene', "Scene")
-
-    def draw_buttons(self, context, layout):
-        layout.prop(self, "aa_samples", text="AA Samples")
 
     def process(self, context, inputs):
         scene = inputs.get("Scene")
         if scene and hasattr(scene, "display"):
+            samples = inputs.get("AA Samples")
             mod = get_active_mod_item()
             if mod and hasattr(scene.display, 'render_aa'):
                 mod.store_original(scene.display, 'render_aa')
             try:
                 if hasattr(scene.display, 'render_aa'):
-                    scene.display.render_aa = self.aa_samples
+                    scene.display.render_aa = samples
             except Exception:
                 pass
         return {"Scene": scene}

--- a/nodes/world_props.py
+++ b/nodes/world_props.py
@@ -2,19 +2,14 @@ import bpy
 from bpy.types import Node
 
 from .base import FNBaseNode
-from ..sockets import FNSocketWorld
-from ..operators import get_active_mod_item, auto_evaluate_if_enabled
+from ..sockets import FNSocketWorld, FNSocketBool
+from ..operators import get_active_mod_item
 
 
 class FNWorldProps(Node, FNBaseNode):
     bl_idname = "FNWorldProps"
     bl_label = "World Properties"
 
-    use_nodes: bpy.props.BoolProperty(
-        name="Use Nodes",
-        default=True,
-        update=auto_evaluate_if_enabled,
-    )
 
     @classmethod
     def poll(cls, ntree):
@@ -22,19 +17,19 @@ class FNWorldProps(Node, FNBaseNode):
 
     def init(self, context):
         self.inputs.new('FNSocketWorld', "World")
+        sock = self.inputs.new('FNSocketBool', "Use Nodes")
+        sock.value = True
         self.outputs.new('FNSocketWorld', "World")
-
-    def draw_buttons(self, context, layout):
-        layout.prop(self, "use_nodes", text="Use Nodes")
 
     def process(self, context, inputs):
         world = inputs.get("World")
         if world:
+            use_nodes = inputs.get("Use Nodes")
             mod = get_active_mod_item()
             if mod:
                 mod.store_original(world, "use_nodes")
             try:
-                world.use_nodes = self.use_nodes
+                world.use_nodes = use_nodes
             except Exception:
                 pass
         return {"World": world}

--- a/sockets.py
+++ b/sockets.py
@@ -1,6 +1,7 @@
 
 import bpy
 from bpy.types import NodeSocket
+from .operators import auto_evaluate_if_enabled
 
 ### Helpers ###
 def _color(r,g,b): return (r,g,b,1.0)
@@ -20,7 +21,7 @@ class FNSocketBool(NodeSocket):
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'CHECKBOX_HLT')
     def draw_color(self, context, node): return _color(0.8, 0.8, 0.2)
-    value: bpy.props.BoolProperty()
+    value: bpy.props.BoolProperty(update=auto_evaluate_if_enabled)
 
 class FNSocketFloat(NodeSocket):
     bl_idname = "FNSocketFloat"
@@ -28,7 +29,7 @@ class FNSocketFloat(NodeSocket):
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'PROP_FLOAT')
     def draw_color(self, context, node): return _color(0.6, 0.8, 0.9)
-    value: bpy.props.FloatProperty()
+    value: bpy.props.FloatProperty(update=auto_evaluate_if_enabled)
 
 class FNSocketInt(NodeSocket):
     bl_idname = "FNSocketInt"
@@ -36,7 +37,7 @@ class FNSocketInt(NodeSocket):
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'SORTSIZE')
     def draw_color(self, context, node): return _color(0.9, 0.7, 0.5)
-    value: bpy.props.IntProperty()
+    value: bpy.props.IntProperty(update=auto_evaluate_if_enabled)
 
 class FNSocketString(NodeSocket):
     bl_idname = "FNSocketString"
@@ -44,7 +45,7 @@ class FNSocketString(NodeSocket):
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'FONT_DATA')
     def draw_color(self, context, node): return _color(0.7, 0.7, 0.7)
-    value: bpy.props.StringProperty()
+    value: bpy.props.StringProperty(update=auto_evaluate_if_enabled)
 
 # Single datablock sockets
 class FNSocketScene(NodeSocket):
@@ -53,7 +54,7 @@ class FNSocketScene(NodeSocket):
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'SCENE_DATA')
     def draw_color(self, context, node): return _color(0.6,0.9,1.0)
-    value: bpy.props.PointerProperty(type=bpy.types.Scene)
+    value: bpy.props.PointerProperty(type=bpy.types.Scene, update=auto_evaluate_if_enabled)
 
 class FNSocketObject(NodeSocket):
     bl_idname = "FNSocketObject"
@@ -62,7 +63,7 @@ class FNSocketObject(NodeSocket):
         _draw_value_socket(self, layout, text, 'OBJECT_DATA')
     # Use Blender's default orange object socket color
     def draw_color(self, context, node): return _color(0.93, 0.62, 0.36)
-    value: bpy.props.PointerProperty(type=bpy.types.Object)
+    value: bpy.props.PointerProperty(type=bpy.types.Object, update=auto_evaluate_if_enabled)
 
 class FNSocketCollection(NodeSocket):
     bl_idname = "FNSocketCollection"
@@ -71,7 +72,7 @@ class FNSocketCollection(NodeSocket):
         _draw_value_socket(self, layout, text, 'OUTLINER_COLLECTION')
     # Blender's default collection socket color is white
     def draw_color(self, context, node): return _color(0.96, 0.96, 0.96)
-    value: bpy.props.PointerProperty(type=bpy.types.Collection)
+    value: bpy.props.PointerProperty(type=bpy.types.Collection, update=auto_evaluate_if_enabled)
 
 class FNSocketCamera(NodeSocket):
     bl_idname = "FNSocketCamera"
@@ -79,7 +80,7 @@ class FNSocketCamera(NodeSocket):
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'CAMERA_DATA')
     def draw_color(self, context, node): return _color(0.8,0.6,0.4)
-    value: bpy.props.PointerProperty(type=bpy.types.Camera)
+    value: bpy.props.PointerProperty(type=bpy.types.Camera, update=auto_evaluate_if_enabled)
 
 class FNSocketImage(NodeSocket):
     bl_idname = "FNSocketImage"
@@ -87,7 +88,7 @@ class FNSocketImage(NodeSocket):
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'IMAGE_DATA')
     def draw_color(self, context, node): return _color(0.8,0.8,0.8)
-    value: bpy.props.PointerProperty(type=bpy.types.Image)
+    value: bpy.props.PointerProperty(type=bpy.types.Image, update=auto_evaluate_if_enabled)
 
 class FNSocketLight(NodeSocket):
     bl_idname = "FNSocketLight"
@@ -95,7 +96,7 @@ class FNSocketLight(NodeSocket):
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'LIGHT_DATA')
     def draw_color(self, context, node): return _color(1.0,0.9,0.3)
-    value: bpy.props.PointerProperty(type=bpy.types.Light)
+    value: bpy.props.PointerProperty(type=bpy.types.Light, update=auto_evaluate_if_enabled)
 
 class FNSocketMaterial(NodeSocket):
     bl_idname = "FNSocketMaterial"
@@ -103,7 +104,7 @@ class FNSocketMaterial(NodeSocket):
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'MATERIAL_DATA')
     def draw_color(self, context, node): return _color(0.9,0.6,0.8)
-    value: bpy.props.PointerProperty(type=bpy.types.Material)
+    value: bpy.props.PointerProperty(type=bpy.types.Material, update=auto_evaluate_if_enabled)
 
 class FNSocketMesh(NodeSocket):
     bl_idname = "FNSocketMesh"
@@ -112,7 +113,7 @@ class FNSocketMesh(NodeSocket):
         _draw_value_socket(self, layout, text, 'MESH_DATA')
     # Match geometry socket color used in Geometry Nodes (green)
     def draw_color(self, context, node): return _color(0.0, 0.84, 0.64)
-    value: bpy.props.PointerProperty(type=bpy.types.Mesh)
+    value: bpy.props.PointerProperty(type=bpy.types.Mesh, update=auto_evaluate_if_enabled)
 
 class FNSocketNodeTree(NodeSocket):
     bl_idname = "FNSocketNodeTree"
@@ -120,7 +121,7 @@ class FNSocketNodeTree(NodeSocket):
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'NODETREE')
     def draw_color(self, context, node): return _color(0.7,0.9,0.7)
-    value: bpy.props.PointerProperty(type=bpy.types.NodeTree)
+    value: bpy.props.PointerProperty(type=bpy.types.NodeTree, update=auto_evaluate_if_enabled)
 
 class FNSocketText(NodeSocket):
     bl_idname = "FNSocketText"
@@ -128,7 +129,7 @@ class FNSocketText(NodeSocket):
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'TEXT')
     def draw_color(self, context, node): return _color(0.9,0.9,0.6)
-    value: bpy.props.PointerProperty(type=bpy.types.Text)
+    value: bpy.props.PointerProperty(type=bpy.types.Text, update=auto_evaluate_if_enabled)
 
 class FNSocketWorkSpace(NodeSocket):
     bl_idname = "FNSocketWorkSpace"
@@ -136,7 +137,7 @@ class FNSocketWorkSpace(NodeSocket):
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'WORKSPACE')
     def draw_color(self, context, node): return _color(0.5,0.7,0.9)
-    value: bpy.props.PointerProperty(type=bpy.types.WorkSpace)
+    value: bpy.props.PointerProperty(type=bpy.types.WorkSpace, update=auto_evaluate_if_enabled)
 
 class FNSocketWorld(NodeSocket):
     bl_idname = "FNSocketWorld"
@@ -144,7 +145,7 @@ class FNSocketWorld(NodeSocket):
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'WORLD')
     def draw_color(self, context, node): return _color(0.8,0.8,0.3)
-    value: bpy.props.PointerProperty(type=bpy.types.World)
+    value: bpy.props.PointerProperty(type=bpy.types.World, update=auto_evaluate_if_enabled)
 
 # List sockets just pass python lists at runtime
 class FNSocketSceneList(NodeSocket):


### PR DESCRIPTION
## Summary
- convert bool/float/int/datablock property fields into socket inputs
- trigger graph reevaluation when socket values change
- remove obsolete property UI for property nodes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859dcf336d48330aea1496bcba876b5