### PR TITLE
Add Import Alembic node

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ File Nodes es un prototipo de addon para Blender que extiende el paradigma proce
 - **Group Input**: expone datablocks del archivo actual.
 - **Scene Input**, **Object Input** y **Collection Input**: permiten referenciar manualmente estos datablocks.
 - **Read Blend File**: importa escenas, colecciones, objetos y mundos desde archivos externos.
+- **Import Alembic**: carga objetos desde un archivo `.abc`.
 - **Create List**, **Get Item by Name** y **Get Item by Index**: operan sobre listas de datablocks.
 - **Link to Scene** y **Link to Collection**: añaden objetos o colecciones a otras estructuras.
 - **Set World to Scene**: ejemplo de nodo de acción que modifica una `Scene`.

--- a/menu.py
+++ b/menu.py
@@ -27,6 +27,7 @@ categories = [
     ]),
     NodeCategory('FILE_NODES_FILE', 'File', items=[
         NodeItem('FNReadBlendNode'),
+        NodeItem('FNImportAlembicNode'),
     ]),
     NodeCategory('FILE_NODES_LIST', 'Lists', items=[
         NodeItem('FNCreateList'),

--- a/modifiers.py
+++ b/modifiers.py
@@ -77,6 +77,8 @@ class FileNodeModItem(PropertyGroup):
             self._original_values["linked_objects"] = []
         if "linked_collections" not in self._original_values:
             self._original_values["linked_collections"] = []
+        if "imported_objects" not in self._original_values:
+            self._original_values["imported_objects"] = []
         return self._original_values
 
     def store_original(self, data, attr):
@@ -109,6 +111,11 @@ class FileNodeModItem(PropertyGroup):
                     coll.children.unlink(child)
             except Exception:
                 pass
+        for obj in storage.get("imported_objects", []):
+            try:
+                bpy.data.objects.remove(obj, do_unlink=True)
+            except Exception:
+                pass
         for k, v in list(storage.items()):
             if isinstance(k, tuple):
                 (ptr, attr) = k
@@ -124,6 +131,7 @@ class FileNodeModItem(PropertyGroup):
         if storage:
             storage.get("linked_objects", []).clear()
             storage.get("linked_collections", []).clear()
+            storage.get("imported_objects", []).clear()
             # remove key entries that hold property values
             for k in list(storage.keys()):
                 if isinstance(k, tuple):

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -3,7 +3,7 @@ import bpy, importlib
 # Node modules used by the File Nodes addon. `input_nodes` now contains
 # FNWorldInputNode for providing World datablocks.
 from . import (
-    read_blend, create_list, get_item_by_name, get_item_by_index,
+    read_blend, import_alembic, create_list, get_item_by_name, get_item_by_index,
     link_to_scene, link_to_collection, set_world, group_input, group_output,
     input_nodes,
     set_render_engine, cycles_scene_props, eevee_scene_props,
@@ -13,7 +13,7 @@ from . import (
 )
 
 _modules = [
-    read_blend, create_list, get_item_by_name, get_item_by_index,
+    read_blend, import_alembic, create_list, get_item_by_name, get_item_by_index,
     link_to_scene, link_to_collection, set_world, group_input, group_output,
     input_nodes,
     set_render_engine, cycles_scene_props, eevee_scene_props,

--- a/nodes/import_alembic.py
+++ b/nodes/import_alembic.py
@@ -1,0 +1,48 @@
+import bpy, os, warnings
+from bpy.types import Node
+from .base import FNBaseNode
+from ..sockets import FNSocketString, FNSocketObjectList
+from ..operators import get_active_mod_item
+
+class FNImportAlembicNode(Node, FNBaseNode):
+    """Import objects from an Alembic file."""
+    bl_idname = "FNImportAlembicNode"
+    bl_label = "Import Alembic"
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        sock = self.inputs.new('FNSocketString', "File Path")
+        sock.display_shape = 'SQUARE'
+        sock = self.outputs.new('FNSocketObjectList', "Objects")
+        sock.display_shape = 'SQUARE'
+
+    def process(self, context, inputs):
+        filepath = inputs.get("File Path", "") or ""
+        abs_path = bpy.path.abspath(filepath)
+        result = {"Objects": []}
+        if not filepath or not os.path.isfile(abs_path):
+            warnings.warn("Invalid filepath")
+            return result
+        before = set(bpy.data.objects)
+        try:
+            bpy.ops.wm.alembic_import(filepath=abs_path, as_background_job=False)
+        except Exception as e:
+            warnings.warn(f"Failed to import Alembic: {e}")
+            return result
+        after = set(bpy.data.objects)
+        imported = [obj for obj in after - before]
+        result["Objects"] = imported
+        mod = get_active_mod_item()
+        if mod:
+            storage = mod._ensure_storage()
+            storage.setdefault("imported_objects", []).extend(imported)
+        return result
+
+def register():
+    bpy.utils.register_class(FNImportAlembicNode)
+
+def unregister():
+    bpy.utils.unregister_class(FNImportAlembicNode)


### PR DESCRIPTION
## Summary
- add `Import Alembic` node implementation
- register new node module
- expose the node in the Add menu
- document the node in README
- support cleanup of imported objects

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a33393f9083309fddde206460da4d