### PR TITLE
Add datablock creation nodes

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -28,6 +28,13 @@ categories = [
     NodeCategory('FILE_NODES_FILE', 'File', items=[
         NodeItem('FNReadBlendNode'),
     ]),
+    NodeCategory('FILE_NODES_NEW', 'New', items=[
+        NodeItem('FNNewScene'),
+        NodeItem('FNNewObject'),
+        NodeItem('FNNewCollection'),
+        NodeItem('FNNewWorld'),
+        NodeItem('FNNewMaterial'),
+    ]),
     NodeCategory('FILE_NODES_LIST', 'Lists', items=[
         NodeItem('FNCreateList'),
         NodeItem('FNGetItemByName'),

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -10,6 +10,7 @@ from . import (
     workbench_scene_props, output_props, scene_props, object_props,
     cycles_object_props, eevee_object_props, collection_props,
     world_props, camera_props, light_props, mesh_props, material_props,
+    new_scene, new_object, new_collection, new_world, new_material,
 )
 
 _modules = [
@@ -20,6 +21,7 @@ _modules = [
     workbench_scene_props, output_props, scene_props, object_props,
     cycles_object_props, eevee_object_props, collection_props,
     world_props, camera_props, light_props, mesh_props, material_props,
+    new_scene, new_object, new_collection, new_world, new_material,
 ]
 
 def register():

--- a/nodes/new_collection.py
+++ b/nodes/new_collection.py
@@ -1,0 +1,51 @@
+import bpy
+from bpy.types import Node
+from .base import FNBaseNode
+from ..sockets import FNSocketCollection
+from ..operators import auto_evaluate_if_enabled
+
+class FNNewCollection(Node, FNBaseNode):
+    bl_idname = "FNNewCollection"
+    bl_label = "New Collection"
+
+    name: bpy.props.StringProperty(name="Name", default="Collection", update=auto_evaluate_if_enabled)
+    color_tag: bpy.props.EnumProperty(
+        name="Color Tag",
+        items=[
+            ('NONE', 'None', ''),
+            ('COLOR_01', '01', ''),
+            ('COLOR_02', '02', ''),
+            ('COLOR_03', '03', ''),
+            ('COLOR_04', '04', ''),
+            ('COLOR_05', '05', ''),
+            ('COLOR_06', '06', ''),
+            ('COLOR_07', '07', ''),
+            ('COLOR_08', '08', ''),
+        ],
+        default='NONE',
+        update=auto_evaluate_if_enabled
+    )
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.outputs.new('FNSocketCollection', "Collection")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "name", text="Name")
+        layout.prop(self, "color_tag", text="Color Tag")
+
+    def process(self, context, inputs):
+        coll = bpy.data.collections.new(self.name)
+        coll.color_tag = self.color_tag
+        return {"Collection": coll}
+
+
+def register():
+    bpy.utils.register_class(FNNewCollection)
+
+
+def unregister():
+    bpy.utils.unregister_class(FNNewCollection)

--- a/nodes/new_material.py
+++ b/nodes/new_material.py
@@ -1,0 +1,33 @@
+import bpy
+from bpy.types import Node
+from .base import FNBaseNode
+from ..sockets import FNSocketMaterial
+from ..operators import auto_evaluate_if_enabled
+
+class FNNewMaterial(Node, FNBaseNode):
+    bl_idname = "FNNewMaterial"
+    bl_label = "New Material"
+
+    name: bpy.props.StringProperty(name="Name", default="Material", update=auto_evaluate_if_enabled)
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.outputs.new('FNSocketMaterial', "Material")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "name", text="Name")
+
+    def process(self, context, inputs):
+        mat = bpy.data.materials.new(self.name)
+        return {"Material": mat}
+
+
+def register():
+    bpy.utils.register_class(FNNewMaterial)
+
+
+def unregister():
+    bpy.utils.unregister_class(FNNewMaterial)

--- a/nodes/new_object.py
+++ b/nodes/new_object.py
@@ -1,0 +1,71 @@
+import bpy
+from bpy.types import Node
+from .base import FNBaseNode
+from ..sockets import (
+    FNSocketObject, FNSocketMesh, FNSocketLight, FNSocketCamera
+)
+from ..operators import auto_evaluate_if_enabled
+
+_object_data_socket = {
+    'EMPTY': None,
+    'MESH': 'FNSocketMesh',
+    'LIGHT': 'FNSocketLight',
+    'CAMERA': 'FNSocketCamera',
+}
+
+class FNNewObject(Node, FNBaseNode):
+    bl_idname = "FNNewObject"
+    bl_label = "New Object"
+
+    name: bpy.props.StringProperty(name="Name", default="Object", update=auto_evaluate_if_enabled)
+    obj_type: bpy.props.EnumProperty(
+        name="Type",
+        items=[
+            ('EMPTY', 'Empty', ''),
+            ('MESH', 'Mesh', ''),
+            ('LIGHT', 'Light', ''),
+            ('CAMERA', 'Camera', ''),
+        ],
+        default='EMPTY',
+        update=lambda self, context: self.update_sockets(context)
+    )
+
+    def update_sockets(self, context):
+        while self.inputs:
+            self.inputs.remove(self.inputs[-1])
+        if _object_data_socket[self.obj_type]:
+            self.inputs.new(_object_data_socket[self.obj_type], "Data")
+        while self.outputs:
+            self.outputs.remove(self.outputs[-1])
+        self.outputs.new('FNSocketObject', "Object")
+        auto_evaluate_if_enabled(context)
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.update_sockets(context)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "name", text="Name")
+        layout.prop(self, "obj_type", text="Type")
+
+    def process(self, context, inputs):
+        data = None
+        if self.obj_type == 'MESH':
+            data = inputs.get("Data") or bpy.data.meshes.new(f"{self.name}Mesh")
+        elif self.obj_type == 'LIGHT':
+            data = inputs.get("Data") or bpy.data.lights.new(f"{self.name}Light", type='POINT')
+        elif self.obj_type == 'CAMERA':
+            data = inputs.get("Data") or bpy.data.cameras.new(f"{self.name}Camera")
+        obj = bpy.data.objects.new(self.name, data)
+        return {"Object": obj}
+
+
+def register():
+    bpy.utils.register_class(FNNewObject)
+
+
+def unregister():
+    bpy.utils.unregister_class(FNNewObject)

--- a/nodes/new_scene.py
+++ b/nodes/new_scene.py
@@ -1,0 +1,33 @@
+import bpy
+from bpy.types import Node
+from .base import FNBaseNode
+from ..sockets import FNSocketScene
+from ..operators import auto_evaluate_if_enabled
+
+class FNNewScene(Node, FNBaseNode):
+    bl_idname = "FNNewScene"
+    bl_label = "New Scene"
+
+    name: bpy.props.StringProperty(name="Name", default="Scene", update=auto_evaluate_if_enabled)
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.outputs.new('FNSocketScene', "Scene")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "name", text="Name")
+
+    def process(self, context, inputs):
+        scene = bpy.data.scenes.new(self.name)
+        return {"Scene": scene}
+
+
+def register():
+    bpy.utils.register_class(FNNewScene)
+
+
+def unregister():
+    bpy.utils.unregister_class(FNNewScene)

--- a/nodes/new_world.py
+++ b/nodes/new_world.py
@@ -1,0 +1,33 @@
+import bpy
+from bpy.types import Node
+from .base import FNBaseNode
+from ..sockets import FNSocketWorld
+from ..operators import auto_evaluate_if_enabled
+
+class FNNewWorld(Node, FNBaseNode):
+    bl_idname = "FNNewWorld"
+    bl_label = "New World"
+
+    name: bpy.props.StringProperty(name="Name", default="World", update=auto_evaluate_if_enabled)
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.outputs.new('FNSocketWorld', "World")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "name", text="Name")
+
+    def process(self, context, inputs):
+        world = bpy.data.worlds.new(self.name)
+        return {"World": world}
+
+
+def register():
+    bpy.utils.register_class(FNNewWorld)
+
+
+def unregister():
+    bpy.utils.unregister_class(FNNewWorld)


### PR DESCRIPTION
## Summary
- add nodes for creating new scenes, objects, collections, worlds and materials
- register the new nodes and expose them in the node menu

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a363c474c8330b4b241a9d780403c