### PR TITLE
Add Import Alembic node

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ File Nodes es un prototipo de addon para Blender que extiende el paradigma proce
 - **Group Input**: expone datablocks del archivo actual.
 - **Scene Input**, **Object Input** y **Collection Input**: permiten referenciar manualmente estos datablocks.
 - **Read Blend File**: importa escenas, colecciones, objetos y mundos desde archivos externos.
+- **Import Alembic**: carga objetos desde archivos `.abc`.
 - **Create List**, **Get Item by Name** y **Get Item by Index**: operan sobre listas de datablocks.
 - **Link to Scene** y **Link to Collection**: añaden objetos o colecciones a otras estructuras.
 - **Set World to Scene**: ejemplo de nodo de acción que modifica una `Scene`.

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -5,7 +5,7 @@ import bpy, importlib
 from . import (
     read_blend, create_list, get_item_by_name, get_item_by_index,
     link_to_scene, link_to_collection, set_world, group_input, group_output,
-    input_nodes,
+    input_nodes, import_alembic,
     set_render_engine, cycles_scene_props, eevee_scene_props,
     workbench_scene_props, output_props, scene_props, object_props,
     cycles_object_props, eevee_object_props, collection_props,
@@ -15,7 +15,7 @@ from . import (
 _modules = [
     read_blend, create_list, get_item_by_name, get_item_by_index,
     link_to_scene, link_to_collection, set_world, group_input, group_output,
-    input_nodes,
+    input_nodes, import_alembic,
     set_render_engine, cycles_scene_props, eevee_scene_props,
     workbench_scene_props, output_props, scene_props, object_props,
     cycles_object_props, eevee_object_props, collection_props,

--- a/nodes/import_alembic.py
+++ b/nodes/import_alembic.py
@@ -1,0 +1,49 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..sockets import FNSocketString, FNSocketObjectList
+from ..operators import get_active_mod_item
+
+
+class FNImportAlembic(Node, FNBaseNode):
+    bl_idname = "FNImportAlembicNode"
+    bl_label = "Import Alembic"
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketString', "File Path")
+        sock = self.outputs.new('FNSocketObjectList', "Objects")
+        sock.display_shape = 'SQUARE'
+
+    def process(self, context, inputs):
+        filepath = inputs.get("File Path") or ""
+        abs_path = bpy.path.abspath(filepath)
+        objects = []
+        if filepath:
+            scene = context.scene
+            before = set(scene.objects)
+            try:
+                bpy.ops.wm.alembic_import(filepath=abs_path)
+            except Exception:
+                return {"Objects": []}
+            for obj in scene.objects:
+                if obj not in before:
+                    objects.append(obj)
+            mod = get_active_mod_item()
+            if mod:
+                root = scene.collection
+                for obj in objects:
+                    mod.remember_object_link(root, obj)
+        return {"Objects": objects}
+
+
+def register():
+    bpy.utils.register_class(FNImportAlembic)
+
+
+def unregister():
+    bpy.utils.unregister_class(FNImportAlembic)


### PR DESCRIPTION
## Summary
- add a new `Import Alembic` node for loading `.abc` files
- register the new node in the addon
- document the node in README

## Testing
- `python3 -m py_compile nodes/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685a33393f9083309fddde206460da4d