### PR TITLE
Fix dynamic socket nodes default inputs

### DIFF
--- a/nodes/create_list.py
+++ b/nodes/create_list.py
@@ -44,7 +44,10 @@ class FNCreateList(Node, FNBaseNode):
     bl_idname = "FNCreateList"
     bl_label = "Create List"
 
-    item_count: bpy.props.IntProperty(default=1)
+    # Provide two sockets by default plus a virtual socket so that
+    # newly added nodes can be used immediately without crashing when
+    # no real sockets exist.
+    item_count: bpy.props.IntProperty(default=2)
 
     data_type: bpy.props.EnumProperty(
         name="Type",
@@ -77,8 +80,12 @@ class FNCreateList(Node, FNBaseNode):
             self.outputs.remove(self.outputs[-1])
         single = _socket_single[self.data_type]
         lst = _socket_list[self.data_type]
-        self.item_count = 1
+        # Two initial sockets are created to prevent crashes that
+        # occurred when only a single real socket existed. The
+        # virtual socket remains available for adding more.
+        self.item_count = 2
         self.inputs.new(single, f"{self.data_type.title()} 1")
+        self.inputs.new(single, f"{self.data_type.title()} 2")
         self.inputs.new('NodeSocketVirtual', "")
         sock = self.outputs.new(lst, f"{self.data_type.title()}s")
         sock.display_shape = 'SQUARE'

--- a/nodes/join_strings.py
+++ b/nodes/join_strings.py
@@ -10,11 +10,17 @@ class FNJoinStrings(Node, FNBaseNode):
     bl_idname = "FNJoinStrings"
     bl_label = "Join Strings"
 
-    item_count: bpy.props.IntProperty(default=1)
+    # Start with two string inputs by default so users can immediately
+    # join at least two items without manually adding sockets.
+    item_count: bpy.props.IntProperty(default=2)
     separator: bpy.props.StringProperty(name="Separator", default="", update=auto_evaluate_if_enabled)
 
     def init(self, context):
+        # Provide two inputs by default to avoid crashes when the node
+        # is evaluated with an empty socket list. Users can add more
+        # sockets via the virtual socket as usual.
         self.inputs.new('FNSocketString', "String 1")
+        self.inputs.new('FNSocketString', "String 2")
         self.inputs.new('NodeSocketVirtual', "")
         self.outputs.new('FNSocketString', "String")
 


### PR DESCRIPTION
## Summary
- prevent crashes when adding dynamic sockets in Join Strings and Create List nodes
- start with two real sockets plus a virtual socket in both nodes

## Testing
- `python -m py_compile nodes/join_strings.py nodes/create_list.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a4278f9988330925c27f918d83d4b