### PR TITLE
Fix link insertion to avoid Blender crash

### DIFF
--- a/nodes/create_list.py
+++ b/nodes/create_list.py
@@ -122,7 +122,10 @@ class FNCreateList(Node, FNBaseNode):
                 len(self.inputs) - 2
             )
             self.item_count += 1
-            self.id_data.links.new(link.from_socket, new_sock)
+            # Reuse the dragged link instead of creating a new one
+            # to avoid potential crashes when the temporary link
+            # is removed by Blender during the operation.
+            link.to_socket = new_sock
             self._ensure_virtual()
             return True
         return False


### PR DESCRIPTION
## Summary
- handle `insert_link` by reusing the temporary link instead of creating a new one

## Testing
- `python3 -m py_compile nodes/create_list.py`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685a4468bd0883309335bf7129653099