### PR TITLE
Fix dynamic socket link reuse

### DIFF
--- a/nodes/group_input.py
+++ b/nodes/group_input.py
@@ -72,7 +72,10 @@ class FNGroupInputNode(Node, FNBaseNode):
             new_item = iface.new_socket(name=name, in_out='INPUT', socket_type=link.to_socket.bl_idname)
             new_sock = self.outputs.new(new_item.socket_type, new_item.name)
             self.outputs.move(self.outputs.find(new_sock.name), len(self.outputs)-1)
-            self.id_data.links.new(new_sock, link.to_socket)
+            # Reuse the dragged link instead of creating a new one to
+            # avoid potential crashes when Blender removes the temporary
+            # link at the end of the operation.
+            link.from_socket = new_sock
             self._ensure_virtual()
             return True
         return False

--- a/nodes/group_output.py
+++ b/nodes/group_output.py
@@ -63,7 +63,10 @@ class FNGroupOutputNode(Node, FNBaseNode):
             new_item = iface.new_socket(name=name, in_out='OUTPUT', socket_type=link.from_socket.bl_idname)
             new_sock = self.inputs.new(new_item.socket_type, new_item.name)
             self.inputs.move(self.inputs.find(new_sock.name), len(self.inputs)-1)
-            self.id_data.links.new(link.from_socket, new_sock)
+            # Reuse the dragged link instead of creating a new one to
+            # avoid potential crashes when Blender removes the temporary
+            # link at the end of the operation.
+            link.to_socket = new_sock
             self._ensure_virtual()
             return True
         return False

--- a/nodes/join_strings.py
+++ b/nodes/join_strings.py
@@ -47,7 +47,10 @@ class FNJoinStrings(Node, FNBaseNode):
             new_sock = self.inputs.new('FNSocketString', f"String {idx}")
             self.inputs.move(self.inputs.find(new_sock.name), len(self.inputs) - 2)
             self.item_count += 1
-            self.id_data.links.new(link.from_socket, new_sock)
+            # Reuse the dragged link instead of creating a new one to
+            # avoid potential crashes when Blender removes the temporary
+            # link at the end of the operation.
+            link.to_socket = new_sock
             self._ensure_virtual()
             return True
         return False


### PR DESCRIPTION
## Summary
- reuse dragged links for dynamic sockets to avoid Blender crash

## Testing
- `python -m py_compile nodes/*.py __init__.py menu.py modifiers.py operators.py sockets.py tree.py ui.py`

------
https://chatgpt.com/codex/tasks/task_e_685a46e5a3e48330be08ddd926750c1f