### PR TITLE
Avoid node lookup when inserting links

### DIFF
--- a/nodes/create_list.py
+++ b/nodes/create_list.py
@@ -111,7 +111,10 @@ class FNCreateList(Node, FNBaseNode):
         return {output_name: lst}
 
     def insert_link(self, link):
-        if link.to_socket.node == self and link.to_socket.bl_idname == 'NodeSocketVirtual':
+        # Blender may crash if we access link.to_socket.node during link creation
+        # because the topology cache is not yet built. Compare sockets directly
+        # instead of accessing the owner node.
+        if self.inputs and link.to_socket == self.inputs[-1] and link.to_socket.bl_idname == 'NodeSocketVirtual':
             idx = self.item_count + 1
             new_sock = self.inputs.new(
                 _socket_single[self.data_type],

--- a/nodes/join_strings.py
+++ b/nodes/join_strings.py
@@ -42,7 +42,9 @@ class FNJoinStrings(Node, FNBaseNode):
         return {"String": joined}
 
     def insert_link(self, link):
-        if link.to_socket.node == self and link.to_socket.bl_idname == 'NodeSocketVirtual':
+        # Accessing link.to_socket.node can crash during link creation.
+        # Instead, compare with the last input socket directly.
+        if self.inputs and link.to_socket == self.inputs[-1] and link.to_socket.bl_idname == 'NodeSocketVirtual':
             idx = self.item_count + 1
             new_sock = self.inputs.new('FNSocketString', f"String {idx}")
             self.inputs.move(self.inputs.find(new_sock.name), len(self.inputs) - 2)


### PR DESCRIPTION
## Summary
- prevent Blender crash by avoiding use of `link.to_socket.node` during link insertion
- rework `insert_link` checks in `Create List` and `Join Strings`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685a48096a9c8330a8e14ad1185ca1bf