### PR TITLE
Fix cleanup of dynamic inputs

### DIFF
--- a/nodes/create_list.py
+++ b/nodes/create_list.py
@@ -136,15 +136,21 @@ class FNCreateList(Node, FNBaseNode):
     def _ensure_virtual(self):
         if not self.inputs:
             return
+
+        real_inputs = [s for s in self.inputs if s.bl_idname != 'NodeSocketVirtual']
+        type_name = self.data_type.title()
+        while len(real_inputs) > 2 and not (real_inputs[-1].is_linked or getattr(real_inputs[-1], 'value', None)):
+            self.inputs.remove(real_inputs[-1])
+            real_inputs.pop()
+            self.item_count -= 1
+
         if self.inputs[-1].bl_idname != 'NodeSocketVirtual':
             self.inputs.new('NodeSocketVirtual', "")
-        last = self.inputs[-1]
-        if last.is_linked or getattr(last, 'value', None):
-            idx = self.item_count + 1
-            last.name = f"{self.data_type.title()} {idx}"
-            self.inputs.new('NodeSocketVirtual', "")
-            self.item_count += 1
-        # ensure virtual socket stays last
+
+        for idx, sock in enumerate(real_inputs, 1):
+            sock.name = f"{type_name} {idx}"
+
+        self.item_count = len(real_inputs)
 
 def register():
     bpy.utils.register_class(FNCreateList)

--- a/nodes/join_strings.py
+++ b/nodes/join_strings.py
@@ -58,14 +58,19 @@ class FNJoinStrings(Node, FNBaseNode):
         return False
 
     def _ensure_virtual(self):
+        real_inputs = [s for s in self.inputs if s.bl_idname != 'NodeSocketVirtual']
+        while len(real_inputs) > 2 and not (real_inputs[-1].is_linked or getattr(real_inputs[-1], 'value', None)):
+            self.inputs.remove(real_inputs[-1])
+            real_inputs.pop()
+            self.item_count -= 1
+
         if not self.inputs or self.inputs[-1].bl_idname != 'NodeSocketVirtual':
             self.inputs.new('NodeSocketVirtual', "")
-        last = self.inputs[-1]
-        if last.is_linked or getattr(last, 'value', None):
-            idx = self.item_count + 1
-            last.name = f"String {idx}"
-            self.inputs.new('NodeSocketVirtual', "")
-            self.item_count += 1
+
+        for idx, sock in enumerate(real_inputs, 1):
+            sock.name = f"String {idx}"
+
+        self.item_count = len(real_inputs)
 
 
 def register():


### PR DESCRIPTION
## Summary
- prune unused input sockets in Join Strings node
- prune unused input sockets in Create List node

## Testing
- `python -m py_compile nodes/create_list.py nodes/join_strings.py`

------
https://chatgpt.com/codex/tasks/task_e_685a4b16e6a48330b9460f09c1affb95