### PR TITLE
Add Set Name nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ File Nodes es un prototipo de addon para Blender que extiende el paradigma proce
 - **Join Strings** y **Split String**: operaciones básicas con cadenas.
 - **Link to Scene** y **Link to Collection**: añaden objetos o colecciones a otras estructuras.
 - **Set World to Scene**: ejemplo de nodo de acción que modifica una `Scene`.
+- **Set Scene Name**, **Set Collection Name** y **Set Object Name**: renombran escenas, colecciones y objetos.
 
 ## Arquitectura general
 1. **NodeTree personalizado**: contenedor del grafo.

--- a/menu.py
+++ b/menu.py
@@ -23,6 +23,7 @@ categories = [
         NodeItem('FNLinkToScene'),
         NodeItem('FNSetWorldNode'),
         NodeItem('FNSetRenderEngine'),
+        NodeItem('FNSetSceneName'),
         NodeItem('FNCyclesSceneProps'),
         NodeItem('FNEeveeSceneProps'),
         NodeItem('FNWorkbenchSceneProps'),
@@ -37,12 +38,14 @@ categories = [
         NodeItem('FNObjectProps'),
         NodeItem('FNCyclesObjectProps'),
         NodeItem('FNEeveeObjectProps'),
+        NodeItem('FNSetObjectName'),
     ]),
     NodeCategory('FILE_NODES_COLLECTION', 'Collection', items=[
         NodeItem('FNCollectionInputNode'),
         NodeItem('FNNewCollection'),
         NodeItem('FNLinkToCollection'),
         NodeItem('FNCollectionProps'),
+        NodeItem('FNSetCollectionName'),
     ]),
     NodeCategory('FILE_NODES_WORLD', 'World', items=[
         NodeItem('FNWorldInputNode'),

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -12,6 +12,7 @@ from . import (
     cycles_object_props, eevee_object_props, collection_props,
     world_props, camera_props, light_props, mesh_props, material_props,
     new_scene, new_object, new_collection, new_world, new_material,
+    set_scene_name, set_collection_name, set_object_name,
 )
 
 _modules = [
@@ -24,6 +25,7 @@ _modules = [
     cycles_object_props, eevee_object_props, collection_props,
     world_props, camera_props, light_props, mesh_props, material_props,
     new_scene, new_object, new_collection, new_world, new_material,
+    set_scene_name, set_collection_name, set_object_name,
 ]
 
 def register():

--- a/nodes/set_collection_name.py
+++ b/nodes/set_collection_name.py
@@ -1,0 +1,41 @@
+import bpy
+from bpy.types import Node
+from .base import FNBaseNode
+from ..sockets import FNSocketCollection, FNSocketString
+from ..operators import get_active_mod_item
+
+
+class FNSetCollectionName(Node, FNBaseNode):
+    bl_idname = "FNSetCollectionName"
+    bl_label = "Set Collection Name"
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketCollection', "Collection")
+        sock = self.inputs.new('FNSocketString', "Name")
+        sock.value = ""
+        self.outputs.new('FNSocketCollection', "Collection")
+
+    def process(self, context, inputs):
+        coll = inputs.get("Collection")
+        if coll:
+            name = inputs.get("Name") or ""
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(coll, "name")
+            try:
+                coll.name = name
+            except Exception:
+                pass
+        return {"Collection": coll}
+
+
+def register():
+    bpy.utils.register_class(FNSetCollectionName)
+
+
+def unregister():
+    bpy.utils.unregister_class(FNSetCollectionName)

--- a/nodes/set_object_name.py
+++ b/nodes/set_object_name.py
@@ -1,0 +1,41 @@
+import bpy
+from bpy.types import Node
+from .base import FNBaseNode
+from ..sockets import FNSocketObject, FNSocketString
+from ..operators import get_active_mod_item
+
+
+class FNSetObjectName(Node, FNBaseNode):
+    bl_idname = "FNSetObjectName"
+    bl_label = "Set Object Name"
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketObject', "Object")
+        sock = self.inputs.new('FNSocketString', "Name")
+        sock.value = ""
+        self.outputs.new('FNSocketObject', "Object")
+
+    def process(self, context, inputs):
+        obj = inputs.get("Object")
+        if obj:
+            name = inputs.get("Name") or ""
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(obj, "name")
+            try:
+                obj.name = name
+            except Exception:
+                pass
+        return {"Object": obj}
+
+
+def register():
+    bpy.utils.register_class(FNSetObjectName)
+
+
+def unregister():
+    bpy.utils.unregister_class(FNSetObjectName)

--- a/nodes/set_scene_name.py
+++ b/nodes/set_scene_name.py
@@ -1,0 +1,41 @@
+import bpy
+from bpy.types import Node
+from .base import FNBaseNode
+from ..sockets import FNSocketScene, FNSocketString
+from ..operators import get_active_mod_item
+
+
+class FNSetSceneName(Node, FNBaseNode):
+    bl_idname = "FNSetSceneName"
+    bl_label = "Set Scene Name"
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        self.inputs.new('FNSocketScene', "Scene")
+        sock = self.inputs.new('FNSocketString', "Name")
+        sock.value = ""
+        self.outputs.new('FNSocketScene', "Scene")
+
+    def process(self, context, inputs):
+        scene = inputs.get("Scene")
+        if scene:
+            name = inputs.get("Name") or ""
+            mod = get_active_mod_item()
+            if mod:
+                mod.store_original(scene, "name")
+            try:
+                scene.name = name
+            except Exception:
+                pass
+        return {"Scene": scene}
+
+
+def register():
+    bpy.utils.register_class(FNSetSceneName)
+
+
+def unregister():
+    bpy.utils.unregister_class(FNSetSceneName)


### PR DESCRIPTION
## Summary
- implement nodes to change datablock names for scenes, collections and objects
- register the new nodes and expose them in the add menu
- mention the new nodes in the README

## Testing
- `python -m py_compile __init__.py menu.py modifiers.py nodes/*.py operators.py sockets.py tree.py ui.py`

------
https://chatgpt.com/codex/tasks/task_e_685a8c0661688330bf4a76b9a9050267