### PR TITLE
Rename Group Input to Interface Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ File Nodes es un prototipo de addon para Blender que extiende el paradigma proce
 - Integrar una pila de *modificadores de archivo* a nivel de `Scene`.
 
 ## Nodos principales
-- **Group Input**: expone datablocks del archivo actual.
+- **Interface Input**: expone datablocks del archivo actual.
 - **Scene Input**, **Object Input** y **Collection Input**: permiten referenciar manualmente estos datablocks.
 - **Read Blend File**: importa escenas, colecciones, objetos y mundos desde archivos externos.
 - **Import Alembic**: carga objetos desde archivos `.abc`.

--- a/menu.py
+++ b/menu.py
@@ -3,7 +3,7 @@ from nodeitems_utils import NodeCategory, NodeItem, register_node_categories, un
 
 categories = [
     NodeCategory('FILE_NODES_GROUP', 'Group', items=[
-        NodeItem('FNGroupInputNode'),
+        NodeItem('FNGroupInputNode', label='Interface Input'),
         NodeItem('FNGroupOutputNode'),
     ]),
     NodeCategory('FILE_NODES_FILE', 'File', items=[

--- a/modifiers.py
+++ b/modifiers.py
@@ -211,7 +211,7 @@ class FN_OT_mod_add(Operator):
         tree = bpy.data.node_groups.new("File Nodes", 'FileNodesTreeType')
         tree.use_fake_user = True
         iface = tree.interface
-        # Add an empty Group Input node so users can create sockets later
+        # Add an empty Interface Input node so users can create sockets later
         in_node = tree.nodes.new('FNGroupInputNode')
         in_node.location = (-200, 0)
         item.node_tree = tree

--- a/nodes/group_input.py
+++ b/nodes/group_input.py
@@ -13,7 +13,7 @@ def _interface_inputs(tree):
 
 class FNGroupInputNode(Node, FNBaseNode):
     bl_idname = "FNGroupInputNode"
-    bl_label = "Group Input"
+    bl_label = "Interface Input"
 
     @classmethod
     def poll(cls, ntree):


### PR DESCRIPTION
## Summary
- rename `FNGroupInputNode` label to "Interface Input"
- update menu item to show "Interface Input"
- update docs and comments referencing "Group Input"

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b22029dd88330873108486fc4f248