### PR TITLE
Handle new read-only NodeLink properties

### DIFF
--- a/nodes/create_list.py
+++ b/nodes/create_list.py
@@ -128,7 +128,9 @@ class FNCreateList(Node, FNBaseNode):
             # Reuse the dragged link instead of creating a new one
             # to avoid potential crashes when the temporary link
             # is removed by Blender during the operation.
-            link.to_socket = new_sock
+            tree = self.id_data
+            tree.links.new(link.from_socket, new_sock)
+            tree.links.remove(link)
             self._ensure_virtual()
             return True
         return False

--- a/nodes/group_input.py
+++ b/nodes/group_input.py
@@ -73,7 +73,8 @@ class FNGroupInputNode(Node, FNBaseNode):
             # Reuse the dragged link instead of creating a new one to
             # avoid potential crashes when Blender removes the temporary
             # link at the end of the operation.
-            link.from_socket = new_sock
+            tree.links.new(new_sock, link.to_socket)
+            tree.links.remove(link)
             self._ensure_virtual()
             return True
         return False

--- a/nodes/group_output.py
+++ b/nodes/group_output.py
@@ -66,7 +66,8 @@ class FNGroupOutputNode(Node, FNBaseNode):
             # Reuse the dragged link instead of creating a new one to
             # avoid potential crashes when Blender removes the temporary
             # link at the end of the operation.
-            link.to_socket = new_sock
+            tree.links.new(link.from_socket, new_sock)
+            tree.links.remove(link)
             self._ensure_virtual()
             return True
         return False

--- a/nodes/join_strings.py
+++ b/nodes/join_strings.py
@@ -52,7 +52,9 @@ class FNJoinStrings(Node, FNBaseNode):
             # Reuse the dragged link instead of creating a new one to
             # avoid potential crashes when Blender removes the temporary
             # link at the end of the operation.
-            link.to_socket = new_sock
+            tree = self.id_data
+            tree.links.new(link.from_socket, new_sock)
+            tree.links.remove(link)
             self._ensure_virtual()
             return True
         return False


### PR DESCRIPTION
## Summary
- fix Blender 4.4 compatibility by not assigning to `NodeLink` sockets
- update `insert_link` methods to recreate links correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b2630940483309065ab8f328bcba8