### PR TITLE
Fix list socket visuals in output nodes

### DIFF
--- a/nodes/output_nodes.py
+++ b/nodes/output_nodes.py
@@ -15,7 +15,8 @@ class FNRenderScenesNode(Node, FNBaseNode):
         return ntree.bl_idname == "FileNodesTreeType"
 
     def init(self, context):
-        self.inputs.new('FNSocketSceneList', "Scenes")
+        sock = self.inputs.new('FNSocketSceneList', "Scenes")
+        sock.display_shape = 'SQUARE'
 
     def draw_buttons(self, context, layout):
         layout.operator('file_nodes.render_scenes', text="Render Scenes")
@@ -34,7 +35,8 @@ class FNOutputScenesNode(Node, FNBaseNode):
         return ntree.bl_idname == "FileNodesTreeType"
 
     def init(self, context):
-        self.inputs.new('FNSocketSceneList', "Scenes")
+        sock = self.inputs.new('FNSocketSceneList', "Scenes")
+        sock.display_shape = 'SQUARE'
 
     def process(self, context, inputs):
         scenes = inputs.get("Scenes") or []


### PR DESCRIPTION
## Summary
- square the list socket on Render Scenes node
- square the list socket on Output Scenes node

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b2743b0388330aa51c975db1374ad