### PR TITLE
Fix insert_link to avoid errors

### DIFF
--- a/nodes/create_list.py
+++ b/nodes/create_list.py
@@ -130,10 +130,9 @@ class FNCreateList(Node, FNBaseNode):
             # is removed by Blender during the operation.
             tree = self.id_data
             tree.links.new(link.from_socket, new_sock)
-            tree.links.remove(link)
             self._ensure_virtual()
-            return True
-        return False
+            return None
+        return None
 
     def _ensure_virtual(self):
         if not self.inputs:

--- a/nodes/group_input.py
+++ b/nodes/group_input.py
@@ -74,10 +74,9 @@ class FNGroupInputNode(Node, FNBaseNode):
             # avoid potential crashes when Blender removes the temporary
             # link at the end of the operation.
             tree.links.new(new_sock, link.to_socket)
-            tree.links.remove(link)
             self._ensure_virtual()
-            return True
-        return False
+            return None
+        return None
 
     def _ensure_virtual(self):
         if not self.outputs or self.outputs[-1].bl_idname != 'NodeSocketVirtual':

--- a/nodes/group_output.py
+++ b/nodes/group_output.py
@@ -67,10 +67,9 @@ class FNGroupOutputNode(Node, FNBaseNode):
             # avoid potential crashes when Blender removes the temporary
             # link at the end of the operation.
             tree.links.new(link.from_socket, new_sock)
-            tree.links.remove(link)
             self._ensure_virtual()
-            return True
-        return False
+            return None
+        return None
 
     def _ensure_virtual(self):
         if not self.inputs or self.inputs[-1].bl_idname != 'NodeSocketVirtual':

--- a/nodes/join_strings.py
+++ b/nodes/join_strings.py
@@ -54,10 +54,9 @@ class FNJoinStrings(Node, FNBaseNode):
             # link at the end of the operation.
             tree = self.id_data
             tree.links.new(link.from_socket, new_sock)
-            tree.links.remove(link)
             self._ensure_virtual()
-            return True
-        return False
+            return None
+        return None
 
     def _ensure_virtual(self):
         real_inputs = [s for s in self.inputs if s.bl_idname != 'NodeSocketVirtual']


### PR DESCRIPTION
## Summary
- avoid returning booleans from `insert_link` implementations
- only create the new link without trying to remove temporary one

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `blender --background --factory-startup --python /tmp/test_blender.py`

------
https://chatgpt.com/codex/tasks/task_e_685b2cab76908330a845bb65462e2c93