### PR TITLE
Track created datablocks for cleanup

### DIFF
--- a/nodes/new_collection.py
+++ b/nodes/new_collection.py
@@ -2,6 +2,7 @@ import bpy
 from bpy.types import Node
 from .base import FNBaseNode
 from ..sockets import FNSocketCollection, FNSocketString
+from ..operators import get_active_mod_item
 
 class FNNewCollection(Node, FNBaseNode):
     bl_idname = "FNNewCollection"
@@ -19,6 +20,9 @@ class FNNewCollection(Node, FNBaseNode):
     def process(self, context, inputs):
         name = inputs.get("Name") or "Collection"
         coll = bpy.data.collections.new(name)
+        mod = get_active_mod_item()
+        if mod:
+            mod.remember_created_id(coll)
         return {"Collection": coll}
 
 

--- a/nodes/new_material.py
+++ b/nodes/new_material.py
@@ -2,6 +2,7 @@ import bpy
 from bpy.types import Node
 from .base import FNBaseNode
 from ..sockets import FNSocketMaterial, FNSocketString
+from ..operators import get_active_mod_item
 
 class FNNewMaterial(Node, FNBaseNode):
     bl_idname = "FNNewMaterial"
@@ -19,6 +20,9 @@ class FNNewMaterial(Node, FNBaseNode):
     def process(self, context, inputs):
         name = inputs.get("Name") or "Material"
         mat = bpy.data.materials.new(name)
+        mod = get_active_mod_item()
+        if mod:
+            mod.remember_created_id(mat)
         return {"Material": mat}
 
 

--- a/nodes/new_object.py
+++ b/nodes/new_object.py
@@ -4,7 +4,7 @@ from .base import FNBaseNode
 from ..sockets import (
     FNSocketObject, FNSocketMesh, FNSocketLight, FNSocketCamera, FNSocketString
 )
-from ..operators import auto_evaluate_if_enabled
+from ..operators import auto_evaluate_if_enabled, get_active_mod_item
 
 _object_data_socket = {
     'EMPTY': None,
@@ -52,14 +52,29 @@ class FNNewObject(Node, FNBaseNode):
 
     def process(self, context, inputs):
         data = None
+        created_data = None
         if self.obj_type == 'MESH':
-            data = inputs.get("Data") or bpy.data.meshes.new(f"{inputs.get('Name') or 'Object'}Mesh")
+            data = inputs.get("Data")
+            if not data:
+                data = bpy.data.meshes.new(f"{inputs.get('Name') or 'Object'}Mesh")
+                created_data = data
         elif self.obj_type == 'LIGHT':
-            data = inputs.get("Data") or bpy.data.lights.new(f"{inputs.get('Name') or 'Object'}Light", type='POINT')
+            data = inputs.get("Data")
+            if not data:
+                data = bpy.data.lights.new(f"{inputs.get('Name') or 'Object'}Light", type='POINT')
+                created_data = data
         elif self.obj_type == 'CAMERA':
-            data = inputs.get("Data") or bpy.data.cameras.new(f"{inputs.get('Name') or 'Object'}Camera")
+            data = inputs.get("Data")
+            if not data:
+                data = bpy.data.cameras.new(f"{inputs.get('Name') or 'Object'}Camera")
+                created_data = data
         name = inputs.get("Name") or "Object"
         obj = bpy.data.objects.new(name, data)
+        mod = get_active_mod_item()
+        if mod:
+            mod.remember_created_id(obj)
+            if created_data:
+                mod.remember_created_id(created_data)
         return {"Object": obj}
 
 

--- a/nodes/new_scene.py
+++ b/nodes/new_scene.py
@@ -23,6 +23,7 @@ class FNNewScene(Node, FNBaseNode):
         mod = get_active_mod_item()
         if mod:
             mod.remember_created_scene(scene)
+            mod.remember_created_id(scene)
         return {"Scene": scene}
 
 

--- a/nodes/new_world.py
+++ b/nodes/new_world.py
@@ -2,6 +2,7 @@ import bpy
 from bpy.types import Node
 from .base import FNBaseNode
 from ..sockets import FNSocketWorld, FNSocketString
+from ..operators import get_active_mod_item
 
 class FNNewWorld(Node, FNBaseNode):
     bl_idname = "FNNewWorld"
@@ -19,6 +20,9 @@ class FNNewWorld(Node, FNBaseNode):
     def process(self, context, inputs):
         name = inputs.get("Name") or "World"
         world = bpy.data.worlds.new(name)
+        mod = get_active_mod_item()
+        if mod:
+            mod.remember_created_id(world)
         return {"World": world}
 
 


### PR DESCRIPTION
## Summary
- store created datablocks in `FileNodeModItem`
- remove created datablocks when resetting to originals
- clear the new collection when modifiers are cleared
- register new datablocks created by new node types

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685baca696dc8330982b6e2b9c96d2db