### PR TITLE
Fix circular import in operators

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -1,6 +1,5 @@
 
 import bpy
-from .tree import FileNodesTree
 from bpy.types import Operator
 from . import ADDON_NAME
 


### PR DESCRIPTION
## Summary
- remove unused FileNodesTree import from `operators.py` to resolve a circular dependency when Blender loads the addon

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8b29f924833094fa521cca91ac9b