### PR TITLE
Update docs and tests for global tree workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ File Nodes es un prototipo de addon para Blender que extiende el paradigma proce
 ## Objetivos del MVP
 - Crear un nuevo `NodeTree` personalizado.
 - Implementar nodos básicos para leer y manipular datablocks.
-- Integrar una pila de *modificadores de archivo* a nivel de `Scene`.
+- Gestionar una lista global de árboles *File Nodes* que se evalúan sobre la escena activa.
 
 ## Nodos principales
 - **Interface Input**: expone datablocks del archivo actual.
@@ -22,15 +22,15 @@ File Nodes es un prototipo de addon para Blender que extiende el paradigma proce
 1. **NodeTree personalizado**: contenedor del grafo.
 2. **Nodos**: clases que heredan de `bpy.types.Node`.
 3. **Sockets**: tipos propios para listas de objetos, escenas, etc.
-4. **File Modifiers**: colección en `Scene` que permite apilar varios grafos.
+4. **Árboles globales**: los `FileNodesTree` residen en `bpy.data.node_groups` y se evalúan de forma conjunta.
 
 ## Modelo de ejecución
-Los nodos se evalúan directamente sobre la escena activa. Antes de cada ejecución los modificadores restauran los valores originales que han guardado para mantener la no destructividad. Esto asegura que los mismos inputs producen siempre los mismos resultados.
+Cada `FileNodesTree` se evalúa globalmente sobre la escena activa. Antes de la ejecución se restauran los valores originales guardados para mantener la no destructividad. Esto asegura que los mismos inputs producen siempre los mismos resultados.
 
 ## Gestión de datablocks
 - Los datos externos se vinculan mediante *library linking* para mantener la no destructividad.
 - Se recomienda marcar los `NodeTree` con *Fake User* para no perderlos al cerrar el archivo.
-- Al desactivar un modificador se restauran los valores previos de la escena.
+- Al desactivar un árbol se restauran los valores previos de la escena.
 - Durante la evaluación la escena se modifica en vivo pero se conservan copias internas para volver al estado previo en la siguiente ejecución.
 
 ## Requisitos

--- a/tests/test_import_alembic_cache.py
+++ b/tests/test_import_alembic_cache.py
@@ -4,7 +4,7 @@ import importlib.util
 import unittest
 from pathlib import Path
 
-# Create fake bpy module
+# Create fake bpy module with minimal API
 _bpy = pytypes.ModuleType('bpy')
 
 class _OpsWM:
@@ -31,19 +31,46 @@ class _Path:
 
 _bpy.path = _Path()
 
+class _Props:
+    def __getattr__(self, name):
+        def _f(*a, **kw):
+            return None
+        return _f
+
+_bpy.props = _Props()
+
 class _Types:
     class Node:
         pass
+    class NodeTree:
+        pass
+    class PropertyGroup:
+        pass
+    class Operator:
+        pass
+    class Scene: pass
+    class Object: pass
+    class Collection: pass
+    class World: pass
+    class Camera: pass
+    class Image: pass
+    class Light: pass
+    class Material: pass
+    class Mesh: pass
+    class Text: pass
+    class WorkSpace: pass
 
 _bpy.types = _Types()
-_bpy.data = pytypes.SimpleNamespace()
+_bpy.utils = pytypes.SimpleNamespace(register_class=lambda c: None, unregister_class=lambda c: None)
+_bpy.data = pytypes.SimpleNamespace(node_groups=[], scenes=pytypes.SimpleNamespace())
 _bpy.__path__ = []
-sys.modules['bpy.types'] = _bpy.types
 sys.modules['bpy'] = _bpy
+sys.modules['bpy.types'] = _bpy.types
 
 # Fake addon package hierarchy for relative imports
 _addon = pytypes.ModuleType('addon')
 _addon.__path__ = ['.']
+_addon.ADDON_NAME = 'addon'
 sys.modules['addon'] = _addon
 _nodes_pkg = pytypes.ModuleType('addon.nodes')
 _nodes_pkg.__path__ = ['nodes']
@@ -56,7 +83,60 @@ sys.modules['addon.sockets'] = _sockets
 _sockets.FNSocketObjectList = FNSocketObjectList
 _sockets.FNSocketString = FNSocketString
 
-# Fake context helper
+# Load tree and operators modules using the fake bpy package
+spec_tree = importlib.util.spec_from_file_location('addon.tree', Path('tree.py'))
+tree_mod = importlib.util.module_from_spec(spec_tree)
+tree_mod.__package__ = 'addon'
+exec(spec_tree.loader.get_code('addon.tree'), tree_mod.__dict__)
+sys.modules['addon.tree'] = tree_mod
+
+spec_ops = importlib.util.spec_from_file_location('addon.operators', Path('operators.py'))
+ops_mod = importlib.util.module_from_spec(spec_ops)
+ops_mod.__package__ = 'addon'
+exec(spec_ops.loader.get_code('addon.operators'), ops_mod.__dict__)
+sys.modules['addon.operators'] = ops_mod
+
+# Load node under test
+spec = importlib.util.spec_from_file_location(
+    'addon.nodes.import_alembic', Path('nodes/import_alembic.py'),
+    submodule_search_locations=['nodes']
+)
+ia = importlib.util.module_from_spec(spec)
+ia.__package__ = 'addon.nodes'
+exec(spec.loader.get_code('addon.nodes.import_alembic'), ia.__dict__)
+
+
+# Helpers for fake node tree evaluation
+class FakeSocket:
+    def __init__(self, name, bl_idname, is_output=False):
+        self.name = name
+        self.bl_idname = bl_idname
+        self.is_output = is_output
+        self.links = []
+        self.is_linked = False
+        self.node = None
+        self.value = None
+
+
+def link_sockets(from_socket, to_socket):
+    link = pytypes.SimpleNamespace(from_socket=from_socket, from_node=from_socket.node,
+                                   to_socket=to_socket, to_node=to_socket.node)
+    to_socket.links.append(link)
+    to_socket.is_linked = True
+
+
+class DummyOutputNode:
+    bl_idname = "FNGroupOutputNode"
+
+    def __init__(self):
+        self.inputs = [FakeSocket("Objects", "FNSocketObjectList")]
+        self.outputs = []
+        for s in self.inputs:
+            s.node = self
+
+    def process(self, context, inputs):
+        return {}
+
 
 def setup_module(module):
     global _context
@@ -66,21 +146,25 @@ def setup_module(module):
 
 class AlembicCacheTest(unittest.TestCase):
     def test_alembic_cached(self):
-        spec = importlib.util.spec_from_file_location(
-            'addon.nodes.import_alembic', Path('nodes/import_alembic.py'),
-            submodule_search_locations=['nodes']
-        )
-        ia = importlib.util.module_from_spec(spec)
-        ia.__package__ = 'addon.nodes'
-        code = Path('nodes/import_alembic.py').read_text()
-        exec(compile(code, 'nodes/import_alembic.py', 'exec'), ia.__dict__)
+        tree = tree_mod.FileNodesTree.__new__(tree_mod.FileNodesTree)
         node = ia.FNImportAlembic.__new__(ia.FNImportAlembic)
-        node.id_data = pytypes.SimpleNamespace(fn_inputs=None)
-        out1 = ia.FNImportAlembic.process(node, _context, {"File Path": "some.abc"})
-        out2 = ia.FNImportAlembic.process(node, _context, {"File Path": "some.abc"})
-        self.assertEqual(_bpy.ops.wm.call_count, 1)
-        self.assertEqual(out1, out2)
-        self.assertEqual(len(out1["Objects"]), 1)
+        node.id_data = tree
+        node.inputs = [FakeSocket("File Path", "FNSocketString")]
+        node.outputs = [FakeSocket("Objects", "FNSocketObjectList", True)]
+        for s in node.inputs + node.outputs:
+            s.node = node
+        node.inputs[0].value = "some.abc"
+
+        out = DummyOutputNode()
+        link_sockets(node.outputs[0], out.inputs[0])
+
+        tree.nodes = [node, out]
+
+        ops_mod._evaluate_tree(tree, _context)
+        ops_mod._evaluate_tree(tree, _context)
+
+        self.assertEqual(_OpsWM.call_count, 1)
+        self.assertEqual(len(_context.scene.objects), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_new_scene_cache.py
+++ b/tests/test_new_scene_cache.py
@@ -4,7 +4,6 @@ import importlib.util
 import unittest
 from pathlib import Path
 
-# Fake bpy module (reuse existing if created by other tests)
 _bpy = sys.modules.get('bpy', pytypes.ModuleType('bpy'))
 
 class _Scenes:
@@ -14,22 +13,49 @@ class _Scenes:
         return pytypes.SimpleNamespace(name=f"{name}")
 
 if not hasattr(_bpy, 'data'):
-    _bpy.data = pytypes.SimpleNamespace(scenes=_Scenes())
+    _bpy.data = pytypes.SimpleNamespace(node_groups=[], scenes=_Scenes())
 else:
+    _bpy.data.node_groups = []
     _bpy.data.scenes = _Scenes()
+
+class _Props:
+    def __getattr__(self, name):
+        def _f(*a, **kw):
+            return None
+        return _f
+
+_bpy.props = getattr(_bpy, 'props', _Props())
 
 class _Types:
     class Node:
         pass
+    class NodeTree:
+        pass
+    class PropertyGroup:
+        pass
+    class Operator:
+        pass
+    class Scene: pass
+    class Object: pass
+    class Collection: pass
+    class World: pass
+    class Camera: pass
+    class Image: pass
+    class Light: pass
+    class Material: pass
+    class Mesh: pass
+    class Text: pass
+    class WorkSpace: pass
 
 _bpy.types = getattr(_bpy, 'types', _Types())
+_bpy.utils = getattr(_bpy, 'utils', pytypes.SimpleNamespace(register_class=lambda c: None, unregister_class=lambda c: None))
 _bpy.__path__ = getattr(_bpy, '__path__', [])
 sys.modules['bpy.types'] = _bpy.types
 sys.modules['bpy'] = _bpy
 
-# Fake addon package hierarchy
 _addon = pytypes.ModuleType('addon')
 _addon.__path__ = ['.']
+_addon.ADDON_NAME = 'addon'
 sys.modules['addon'] = _addon
 _nodes_pkg = pytypes.ModuleType('addon.nodes')
 _nodes_pkg.__path__ = ['nodes']
@@ -44,28 +70,83 @@ class FNSocketString: pass
 _sockets.FNSocketScene = FNSocketScene
 _sockets.FNSocketString = FNSocketString
 
+spec_tree = importlib.util.spec_from_file_location('addon.tree', Path('tree.py'))
+tree_mod = importlib.util.module_from_spec(spec_tree)
+tree_mod.__package__ = 'addon'
+exec(spec_tree.loader.get_code('addon.tree'), tree_mod.__dict__)
+sys.modules['addon.tree'] = tree_mod
+
+spec_ops = importlib.util.spec_from_file_location('addon.operators', Path('operators.py'))
+ops_mod = importlib.util.module_from_spec(spec_ops)
+ops_mod.__package__ = 'addon'
+exec(spec_ops.loader.get_code('addon.operators'), ops_mod.__dict__)
+sys.modules['addon.operators'] = ops_mod
+
+spec = importlib.util.spec_from_file_location(
+    'addon.nodes.new_scene', Path('nodes/new_scene.py'),
+    submodule_search_locations=['nodes']
+)
+ns = importlib.util.module_from_spec(spec)
+ns.__package__ = 'addon.nodes'
+exec(spec.loader.get_code('addon.nodes.new_scene'), ns.__dict__)
+
+class FakeSocket:
+    def __init__(self, name, bl_idname, is_output=False):
+        self.name = name
+        self.bl_idname = bl_idname
+        self.is_output = is_output
+        self.links = []
+        self.is_linked = False
+        self.node = None
+        self.value = None
+
+
+def link_sockets(from_socket, to_socket):
+    link = pytypes.SimpleNamespace(from_socket=from_socket, from_node=from_socket.node,
+                                   to_socket=to_socket, to_node=to_socket.node)
+    to_socket.links.append(link)
+    to_socket.is_linked = True
+
+
+class DummyOutputNode:
+    bl_idname = "FNGroupOutputNode"
+
+    def __init__(self):
+        self.inputs = [FakeSocket("Scene", "FNSocketScene")]
+        self.outputs = []
+        for s in self.inputs:
+            s.node = self
+
+    def process(self, context, inputs):
+        return {}
 
 
 def setup_module(module):
     global _context
     _context = pytypes.SimpleNamespace()
 
+
 class NewSceneCacheTest(unittest.TestCase):
     def test_scene_cached(self):
-        spec = importlib.util.spec_from_file_location(
-            'addon.nodes.new_scene', Path('nodes/new_scene.py'),
-            submodule_search_locations=['nodes']
-        )
-        ns = importlib.util.module_from_spec(spec)
-        ns.__package__ = 'addon.nodes'
-        code = Path('nodes/new_scene.py').read_text()
-        exec(compile(code, 'nodes/new_scene.py', 'exec'), ns.__dict__)
+        tree = tree_mod.FileNodesTree.__new__(tree_mod.FileNodesTree)
         node = ns.FNNewScene.__new__(ns.FNNewScene)
-        node.id_data = pytypes.SimpleNamespace(fn_inputs=None)
-        out1 = ns.FNNewScene.process(node, _context, {"Name": "Scene"})
-        out2 = ns.FNNewScene.process(node, _context, {"Name": "Scene"})
+        node.id_data = tree
+        node.inputs = [FakeSocket("Name", "FNSocketString")]
+        node.outputs = [FakeSocket("Scene", "FNSocketScene", True)]
+        for s in node.inputs + node.outputs:
+            s.node = node
+        node.inputs[0].value = "Scene"
+
+        out = DummyOutputNode()
+        link_sockets(node.outputs[0], out.inputs[0])
+
+        tree.nodes = [node, out]
+
+        ops_mod._evaluate_tree(tree, _context)
+        ops_mod._evaluate_tree(tree, _context)
+
         self.assertEqual(_bpy.data.scenes.call_count, 1)
-        self.assertEqual(out1, out2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- document global File Nodes tree workflow
- switch tests to evaluate `FileNodesTree` directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8ca2be908330bc73670fc84e0c0e