### PR TITLE
Remove unused stack index property

### DIFF
--- a/tree.py
+++ b/tree.py
@@ -201,7 +201,6 @@ class FileNodesTree(NodeTree):
     bl_use_group_interface = True
 
     fn_enabled: bpy.props.BoolProperty(name='Enabled', default=True)
-    fn_stack_index: bpy.props.IntProperty(name='Stack Index', default=0, min=0)
     fn_inputs: bpy.props.PointerProperty(type=FileNodesTreeInputs)
 
     # Poll: always available


### PR DESCRIPTION
## Summary
- drop obsolete `fn_stack_index` property
- keep the `fn_enabled` toggle to disable trees individually

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8c95f46c8330ab186d910ee5cd1e