### PR TITLE
Fix node insert_link operations

### DIFF
--- a/nodes/create_list.py
+++ b/nodes/create_list.py
@@ -125,13 +125,14 @@ class FNCreateList(Node, FNBaseNode):
                 len(self.inputs) - 2
             )
             self.item_count += 1
-            # Reuse the dragged link instead of creating a new one
-            # to avoid potential crashes when the temporary link
-            # is removed by Blender during the operation.
+            # Reuse the dragged link instead of letting Blender create a new one
+            # and remove the original temporary link so the operation completes
+            # without errors.
             tree = self.id_data
             tree.links.new(link.from_socket, new_sock)
+            tree.links.remove(link)
             self._ensure_virtual()
-            return None
+            return {'FINISHED'}
         return None
 
     def _ensure_virtual(self):

--- a/nodes/group_input.py
+++ b/nodes/group_input.py
@@ -72,12 +72,12 @@ class FNGroupInputNode(Node, FNBaseNode):
             new_item = iface.new_socket(name=name, in_out='INPUT', socket_type=link.to_socket.bl_idname)
             new_sock = self.outputs.new(new_item.socket_type, new_item.name)
             self.outputs.move(self.outputs.find(new_sock.name), len(self.outputs)-1)
-            # Reuse the dragged link instead of creating a new one to
-            # avoid potential crashes when Blender removes the temporary
-            # link at the end of the operation.
+            # Reuse the dragged link, remove Blender's temporary one and
+            # return a success status so no additional link is created.
             tree.links.new(new_sock, link.to_socket)
+            tree.links.remove(link)
             self._ensure_virtual()
-            return None
+            return {'FINISHED'}
         return None
 
     def _ensure_virtual(self):

--- a/nodes/group_output.py
+++ b/nodes/group_output.py
@@ -63,12 +63,12 @@ class FNGroupOutputNode(Node, FNBaseNode):
             new_item = iface.new_socket(name=name, in_out='OUTPUT', socket_type=link.from_socket.bl_idname)
             new_sock = self.inputs.new(new_item.socket_type, new_item.name)
             self.inputs.move(self.inputs.find(new_sock.name), len(self.inputs)-1)
-            # Reuse the dragged link instead of creating a new one to
-            # avoid potential crashes when Blender removes the temporary
-            # link at the end of the operation.
+            # Reuse the dragged link, remove Blender's temporary one and
+            # return success so Blender does not create another link.
             tree.links.new(link.from_socket, new_sock)
+            tree.links.remove(link)
             self._ensure_virtual()
-            return None
+            return {'FINISHED'}
         return None
 
     def _ensure_virtual(self):

--- a/nodes/join_strings.py
+++ b/nodes/join_strings.py
@@ -49,13 +49,13 @@ class FNJoinStrings(Node, FNBaseNode):
             new_sock = self.inputs.new('FNSocketString', f"String {idx}")
             self.inputs.move(self.inputs.find(new_sock.name), len(self.inputs) - 2)
             self.item_count += 1
-            # Reuse the dragged link instead of creating a new one to
-            # avoid potential crashes when Blender removes the temporary
-            # link at the end of the operation.
+            # Reuse the dragged link and remove the temporary one so the
+            # operation succeeds without Blender creating another link.
             tree = self.id_data
             tree.links.new(link.from_socket, new_sock)
+            tree.links.remove(link)
             self._ensure_virtual()
-            return None
+            return {'FINISHED'}
         return None
 
     def _ensure_virtual(self):


### PR DESCRIPTION
## Summary
- handle link deletion during link insertion for nodes with virtual sockets
- update link insertion for create list, join strings, group input and output nodes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cefd59e94833099fe6d154686efa0