### PR TITLE
Fix link removal when creating sockets

### DIFF
--- a/nodes/create_list.py
+++ b/nodes/create_list.py
@@ -130,7 +130,10 @@ class FNCreateList(Node, FNBaseNode):
             # without errors.
             tree = self.id_data
             tree.links.new(link.from_socket, new_sock)
-            tree.links.remove(link)
+            # Remove Blender's temporary link if it exists to avoid runtime
+            # errors when Blender has not added the link to the tree yet.
+            if link in tree.links:
+                tree.links.remove(link)
             self._ensure_virtual()
             return {'FINISHED'}
         return None

--- a/nodes/group_input.py
+++ b/nodes/group_input.py
@@ -75,7 +75,9 @@ class FNGroupInputNode(Node, FNBaseNode):
             # Reuse the dragged link, remove Blender's temporary one and
             # return a success status so no additional link is created.
             tree.links.new(new_sock, link.to_socket)
-            tree.links.remove(link)
+            # Remove the temporary link if it exists to prevent errors
+            if link in tree.links:
+                tree.links.remove(link)
             self._ensure_virtual()
             return {'FINISHED'}
         return None

--- a/nodes/group_output.py
+++ b/nodes/group_output.py
@@ -66,7 +66,9 @@ class FNGroupOutputNode(Node, FNBaseNode):
             # Reuse the dragged link, remove Blender's temporary one and
             # return success so Blender does not create another link.
             tree.links.new(link.from_socket, new_sock)
-            tree.links.remove(link)
+            # Remove temporary link if Blender already added it
+            if link in tree.links:
+                tree.links.remove(link)
             self._ensure_virtual()
             return {'FINISHED'}
         return None

--- a/nodes/join_strings.py
+++ b/nodes/join_strings.py
@@ -53,7 +53,9 @@ class FNJoinStrings(Node, FNBaseNode):
             # operation succeeds without Blender creating another link.
             tree = self.id_data
             tree.links.new(link.from_socket, new_sock)
-            tree.links.remove(link)
+            # Safely remove Blender's temporary link if it was added
+            if link in tree.links:
+                tree.links.remove(link)
             self._ensure_virtual()
             return {'FINISHED'}
         return None


### PR DESCRIPTION
## Summary
- avoid removing links that were never added by Blender
- handle group input and output nodes the same way
- safely remove temp links for join strings
- update create list link removal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cf989247c8330b564ebdce5588e41