### PR TITLE
Fix link removal check in insert_link

### DIFF
--- a/nodes/create_list.py
+++ b/nodes/create_list.py
@@ -130,9 +130,10 @@ class FNCreateList(Node, FNBaseNode):
             # without errors.
             tree = self.id_data
             tree.links.new(link.from_socket, new_sock)
-            # Remove Blender's temporary link if it exists to avoid runtime
-            # errors when Blender has not added the link to the tree yet.
-            if link in tree.links:
+            # Remove Blender's temporary link if it exists. Some Blender
+            # versions raise a TypeError when using `link in tree.links`, so
+            # check membership manually.
+            if any(l is link for l in tree.links):
                 tree.links.remove(link)
             self._ensure_virtual()
             return {'FINISHED'}

--- a/nodes/group_input.py
+++ b/nodes/group_input.py
@@ -75,8 +75,10 @@ class FNGroupInputNode(Node, FNBaseNode):
             # Reuse the dragged link, remove Blender's temporary one and
             # return a success status so no additional link is created.
             tree.links.new(new_sock, link.to_socket)
-            # Remove the temporary link if it exists to prevent errors
-            if link in tree.links:
+            # Remove the temporary link if it exists. Some Blender versions
+            # raise TypeError when checking membership with `in`, so check
+            # manually using object identity.
+            if any(l is link for l in tree.links):
                 tree.links.remove(link)
             self._ensure_virtual()
             return {'FINISHED'}

--- a/nodes/group_output.py
+++ b/nodes/group_output.py
@@ -66,8 +66,10 @@ class FNGroupOutputNode(Node, FNBaseNode):
             # Reuse the dragged link, remove Blender's temporary one and
             # return success so Blender does not create another link.
             tree.links.new(link.from_socket, new_sock)
-            # Remove temporary link if Blender already added it
-            if link in tree.links:
+            # Remove temporary link if Blender already added it. Checking with
+            # `in` can raise TypeError on some Blender versions, so test
+            # manually using identity.
+            if any(l is link for l in tree.links):
                 tree.links.remove(link)
             self._ensure_virtual()
             return {'FINISHED'}

--- a/nodes/join_strings.py
+++ b/nodes/join_strings.py
@@ -53,8 +53,9 @@ class FNJoinStrings(Node, FNBaseNode):
             # operation succeeds without Blender creating another link.
             tree = self.id_data
             tree.links.new(link.from_socket, new_sock)
-            # Safely remove Blender's temporary link if it was added
-            if link in tree.links:
+            # Safely remove Blender's temporary link if it was added. Avoid
+            # using `in` which can raise TypeError; iterate manually instead.
+            if any(l is link for l in tree.links):
                 tree.links.remove(link)
             self._ensure_virtual()
             return {'FINISHED'}


### PR DESCRIPTION
## Summary
- ensure link removal uses identity checks
- update nodes to remove temporary links safely

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cfa8bb4608330bc011a7ee66bef15