### PR TITLE
Use FNSocketString for name inputs

### DIFF
--- a/nodes/get_item_by_name.py
+++ b/nodes/get_item_by_name.py
@@ -64,7 +64,6 @@ class FNGetItemByName(Node, FNBaseNode):
         update=lambda self, context: self.update_type(context)
     )
 
-    item_name: bpy.props.StringProperty(name='Name', default='', update=auto_evaluate_if_enabled)
 
     def update_type(self, context):
         self.update_sockets()
@@ -79,6 +78,7 @@ class FNGetItemByName(Node, FNBaseNode):
         single = _socket_single[self.data_type]
         sock = self.inputs.new(list_sock, f"{self.data_type.title()}s")
         sock.display_shape = 'SQUARE'
+        self.inputs.new('FNSocketString', "Name")
         self.outputs.new(single, self.data_type.title())
 
     def init(self, context):
@@ -86,13 +86,13 @@ class FNGetItemByName(Node, FNBaseNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "data_type", text="Type")
-        layout.prop(self, "item_name", text="Name")
 
     def process(self, context, inputs):
         lst = inputs.get(f"{self.data_type.title()}s", [])
+        name = inputs.get("Name") or ""
         target = None
         for item in lst:
-            if item and item.name == self.item_name:
+            if item and item.name == name:
                 target = item
                 break
         return {self.data_type.title(): target}

--- a/nodes/input_nodes.py
+++ b/nodes/input_nodes.py
@@ -80,21 +80,19 @@ class FNSceneInputNode(Node, FNCacheIDMixin, FNBaseNode):
     bl_label = "Scene Input"
 
     value: bpy.props.PointerProperty(type=bpy.types.Scene, update=auto_evaluate_if_enabled)
-    new_name: bpy.props.StringProperty(update=auto_evaluate_if_enabled, name="Name")
 
     def init(self, context):
+        self.inputs.new('FNSocketString', "Name")
         self.outputs.new('FNSocketScene', "Scene")
-        self.new_name = ""
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "value", text="Scene")
-        layout.prop(self, "new_name")
 
     def process(self, context, inputs):
         scene = self.value
         if not scene:
             return {"Scene": None}
-        name = self.new_name or scene.name
+        name = inputs.get("Name") or scene.name
         key = (scene.as_pointer(), name)
         cached = self.cache_get(key)
         if cached is not None:

--- a/tests/test_scene_input_duplicate.py
+++ b/tests/test_scene_input_duplicate.py
@@ -139,12 +139,12 @@ class SceneInputDuplicateTest(unittest.TestCase):
         tree = tree_mod.FileNodesTree.__new__(tree_mod.FileNodesTree)
         node = ins.FNSceneInputNode.__new__(ins.FNSceneInputNode)
         node.id_data = tree
-        node.inputs = []
+        node.inputs = [FakeSocket("Name", "FNSocketString")]
         node.outputs = [FakeSocket("Scene", "FNSocketScene", True)]
-        for s in node.outputs:
+        for s in node.inputs + node.outputs:
             s.node = node
         node.value = _DummyScene("Base")
-        node.new_name = "Copy"
+        node.inputs[0].value = "Copy"
 
         out = DummyOutputNode()
         link_sockets(node.outputs[0], out.inputs[0])


### PR DESCRIPTION
## Summary
- convert `Name` input of `Scene Input` node into a string socket
- replace the property in `Get Item by Name` with a string socket
- adjust unit test for the new `Scene Input` API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d3d1247bc8330904819bb61fd8557