### PR TITLE
Prevent ID writes during UI draw

### DIFF
--- a/tree.py
+++ b/tree.py
@@ -203,6 +203,10 @@ class FileNodesTree(NodeTree):
     fn_enabled: bpy.props.BoolProperty(name='Enabled', default=True)
     fn_inputs: bpy.props.PointerProperty(type=FileNodesTreeInputs)
 
+    def interface_update(self, context=None):
+        if getattr(self, "fn_inputs", None):
+            self.fn_inputs.sync_inputs(self)
+
     # Poll: always available
     @classmethod
     def poll(cls, context):

--- a/ui.py
+++ b/ui.py
@@ -26,7 +26,6 @@ class FILE_NODES_PT_global(Panel):
 
         tree = scene.file_nodes_tree
         if tree and getattr(tree, "fn_inputs", None):
-            tree.fn_inputs.sync_inputs(tree)
             box = layout.box()
             for inp in tree.fn_inputs.inputs:
                 prop = inp.prop_name()
@@ -34,9 +33,18 @@ class FILE_NODES_PT_global(Panel):
                     box.prop(inp, prop, text=inp.name)
 
 
+def _tree_prop_update(self, context):
+    tree = self.file_nodes_tree
+    if tree and getattr(tree, "fn_inputs", None):
+        tree.fn_inputs.sync_inputs(tree)
+
+
 def register():
     bpy.utils.register_class(FILE_NODES_PT_global)
-    bpy.types.Scene.file_nodes_tree = bpy.props.PointerProperty(type=FileNodesTree)
+    bpy.types.Scene.file_nodes_tree = bpy.props.PointerProperty(
+        type=FileNodesTree,
+        update=_tree_prop_update,
+    )
 
 
 def unregister():


### PR DESCRIPTION
## Summary
- avoid writing to ID data in the panel draw function
- sync inputs on tree interface updates and when selecting a tree

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dbd2f825c83308c9e6c84a81d8bce