### PR TITLE
Add Group Instance node

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ File Nodes es un prototipo de addon para Blender que extiende el paradigma proce
 - **Link to Scene** y **Link to Collection**: añaden objetos o colecciones a otras estructuras.
 - **Set World to Scene**: ejemplo de nodo de acción que modifica una `Scene`.
 - **Set Scene Name**, **Set Collection Name** y **Set Object Name**: renombran escenas, colecciones y objetos.
+- **Group Instance**: ejecuta otro árbol de File Nodes y devuelve sus salidas.
 
 ## Arquitectura general
 1. **NodeTree personalizado**: contenedor del grafo.

--- a/menu.py
+++ b/menu.py
@@ -5,6 +5,7 @@ categories = [
     NodeCategory('FILE_NODES_GROUP', 'Group', items=[
         NodeItem('FNGroupInputNode', label='Interface Input'),
         NodeItem('FNGroupOutputNode'),
+        NodeItem('FNGroupInstanceNode'),
     ]),
     NodeCategory('FILE_NODES_FILE', 'File', items=[
         NodeItem('FNReadBlendNode'),

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -5,7 +5,7 @@ import bpy, importlib
 from . import (
     read_blend, create_list, get_item_by_name, get_item_by_index,
     link_to_scene, link_to_collection, set_world, group_input, group_output,
-    input_nodes, import_alembic, output_nodes,
+    group_instance, input_nodes, import_alembic, output_nodes,
     join_strings, split_string,
     set_render_engine, cycles_scene_props, eevee_scene_props,
     workbench_scene_props, output_props, scene_props, object_props,
@@ -19,7 +19,7 @@ from . import (
 _modules = [
     read_blend, create_list, get_item_by_name, get_item_by_index,
     link_to_scene, link_to_collection, set_world, group_input, group_output,
-    input_nodes, import_alembic, output_nodes,
+    group_instance, input_nodes, import_alembic, output_nodes,
     join_strings, split_string,
     set_render_engine, cycles_scene_props, eevee_scene_props,
     workbench_scene_props, output_props, scene_props, object_props,

--- a/nodes/group_instance.py
+++ b/nodes/group_instance.py
@@ -1,0 +1,135 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from .. import operators
+
+
+class FNGroupInstanceNode(Node, FNBaseNode):
+    bl_idname = "FNGroupInstanceNode"
+    bl_label = "Group Instance"
+
+    def _tree_poll(self, tree):
+        return getattr(tree, "bl_idname", None) == "FileNodesTreeType"
+
+    def _tree_update(self, context):
+        self._sync_sockets()
+        operators.auto_evaluate_if_enabled(context)
+
+    node_tree: bpy.props.PointerProperty(
+        type=bpy.types.NodeTree,
+        poll=_tree_poll,
+        update=_tree_update,
+    )
+
+    def init(self, context):
+        self._sync_sockets()
+
+    def _sync_sockets(self):
+        while self.inputs:
+            self.inputs.remove(self.inputs[-1])
+        while self.outputs:
+            self.outputs.remove(self.outputs[-1])
+        tree = getattr(self, "node_tree", None)
+        iface = getattr(tree, "interface", None)
+        if not tree or not iface:
+            return
+        for item in iface.items_tree:
+            if getattr(item, "in_out", None) == "INPUT":
+                self.inputs.new(item.socket_type, item.name)
+            elif getattr(item, "in_out", None) == "OUTPUT":
+                self.outputs.new(item.socket_type, item.name)
+
+    def process(self, context, inputs):
+        tree = self.node_tree
+        if not tree:
+            return {sock.name: None for sock in self.outputs}
+        ctx = getattr(tree, "fn_inputs", None)
+        if ctx:
+            ctx.sync_inputs(tree)
+            ctx.prepare_eval_scene(getattr(context, "scene", None))
+            for inp in ctx.inputs:
+                val = inputs.get(inp.name)
+                prop = getattr(inp, "prop_name", lambda: "value")()
+                setattr(inp, prop, val)
+        operators._evaluate_tree(tree, context)
+
+        resolved = {}
+        _list_to_single = {
+            "FNSocketSceneList": "FNSocketScene",
+            "FNSocketObjectList": "FNSocketObject",
+            "FNSocketCollectionList": "FNSocketCollection",
+            "FNSocketWorldList": "FNSocketWorld",
+            "FNSocketCameraList": "FNSocketCamera",
+            "FNSocketImageList": "FNSocketImage",
+            "FNSocketLightList": "FNSocketLight",
+            "FNSocketMaterialList": "FNSocketMaterial",
+            "FNSocketMeshList": "FNSocketMesh",
+            "FNSocketNodeTreeList": "FNSocketNodeTree",
+            "FNSocketStringList": "FNSocketString",
+            "FNSocketTextList": "FNSocketText",
+            "FNSocketWorkSpaceList": "FNSocketWorkSpace",
+        }
+
+        def eval_socket(sock):
+            if not sock:
+                return None
+            if sock.is_linked and getattr(sock, "links", None):
+                single = _list_to_single.get(sock.bl_idname)
+                if getattr(sock, "is_multi_input", False):
+                    values = []
+                    for link in sock.links:
+                        from_sock = link.from_socket
+                        val = eval_node(from_sock.node)[from_sock.name]
+                        if single and from_sock.bl_idname == single:
+                            if val is not None:
+                                values.append(val)
+                        else:
+                            values.append(val)
+                    return values
+                else:
+                    link = sock.links[0]
+                    val = eval_node(link.from_node)[link.from_socket.name]
+                    if single and link.from_socket.bl_idname == single:
+                        return [val] if val is not None else []
+                    return val
+            if hasattr(sock, "value"):
+                return sock.value
+            return None
+
+        def eval_node(node):
+            if node in resolved:
+                return resolved[node]
+            node_inputs = {s.name: eval_socket(s) for s in node.inputs}
+            node_outputs = {}
+            if hasattr(node, "process"):
+                node_outputs = node.process(context, node_inputs) or {}
+            for s in node.outputs:
+                node_outputs.setdefault(s.name, None)
+            resolved[node] = node_outputs
+            return node_outputs
+
+        # pick first group output node
+        out_node = None
+        for n in getattr(tree, "nodes", []):
+            if getattr(n, "bl_idname", "") == "FNGroupOutputNode":
+                out_node = n
+                break
+        result = {}
+        iface = getattr(tree, "interface", None)
+        if out_node and iface:
+            for item in iface.items_tree:
+                if getattr(item, "in_out", None) == "OUTPUT":
+                    sock = next((s for s in out_node.inputs if s.name == item.name), None)
+                    result[item.name] = eval_socket(sock)
+        for s in self.outputs:
+            result.setdefault(s.name, None)
+        return result
+
+
+def register():
+    bpy.utils.register_class(FNGroupInstanceNode)
+
+
+def unregister():
+    bpy.utils.unregister_class(FNGroupInstanceNode)

--- a/tests/test_group_instance.py
+++ b/tests/test_group_instance.py
@@ -1,0 +1,230 @@
+import types as pytypes
+import sys
+import importlib.util
+import unittest
+from pathlib import Path
+
+# Minimal fake bpy module
+_bpy = pytypes.ModuleType('bpy')
+
+class _Props:
+    def __getattr__(self, name):
+        def _f(*a, **kw):
+            return None
+        return _f
+_bpy.props = _Props()
+
+class _Types:
+    class Node: pass
+    class NodeTree: pass
+    class PropertyGroup: pass
+    class Operator: pass
+    class Scene: pass
+    class Object: pass
+    class Collection: pass
+    class World: pass
+    class Camera: pass
+    class Image: pass
+    class Light: pass
+    class Material: pass
+    class Mesh: pass
+    class Text: pass
+    class WorkSpace: pass
+_bpy.types = _Types()
+_bpy.utils = pytypes.SimpleNamespace(register_class=lambda c: None, unregister_class=lambda c: None)
+_bpy.data = pytypes.SimpleNamespace(node_groups=[])
+_bpy.__path__ = []
+
+sys.modules['bpy'] = _bpy
+sys.modules['bpy.types'] = _bpy.types
+
+# Fake addon package hierarchy
+_addon = pytypes.ModuleType('addon')
+_addon.__path__ = ['.']
+_addon.ADDON_NAME = 'addon'
+sys.modules['addon'] = _addon
+_nodes_pkg = pytypes.ModuleType('addon.nodes')
+_nodes_pkg.__path__ = ['nodes']
+sys.modules['addon.nodes'] = _nodes_pkg
+
+# Fake sockets
+_sockets = pytypes.ModuleType('addon.sockets')
+class FNSocketString: pass
+sys.modules['addon.sockets'] = _sockets
+_sockets.FNSocketString = FNSocketString
+
+# Load required modules
+spec_ops = importlib.util.spec_from_file_location('addon.operators', Path('operators.py'))
+ops_mod = importlib.util.module_from_spec(spec_ops)
+ops_mod.__package__ = 'addon'
+exec(spec_ops.loader.get_code('addon.operators'), ops_mod.__dict__)
+sys.modules['addon.operators'] = ops_mod
+
+spec_gi = importlib.util.spec_from_file_location('addon.nodes.group_input', Path('nodes/group_input.py'), submodule_search_locations=['nodes'])
+gi_mod = importlib.util.module_from_spec(spec_gi)
+gi_mod.__package__ = 'addon.nodes'
+exec(spec_gi.loader.get_code('addon.nodes.group_input'), gi_mod.__dict__)
+sys.modules['addon.nodes.group_input'] = gi_mod
+
+spec_go = importlib.util.spec_from_file_location('addon.nodes.group_output', Path('nodes/group_output.py'), submodule_search_locations=['nodes'])
+go_mod = importlib.util.module_from_spec(spec_go)
+go_mod.__package__ = 'addon.nodes'
+exec(spec_go.loader.get_code('addon.nodes.group_output'), go_mod.__dict__)
+sys.modules['addon.nodes.group_output'] = go_mod
+
+spec_inst = importlib.util.spec_from_file_location('addon.nodes.group_instance', Path('nodes/group_instance.py'), submodule_search_locations=['nodes'])
+inst_mod = importlib.util.module_from_spec(spec_inst)
+inst_mod.__package__ = 'addon.nodes'
+exec(spec_inst.loader.get_code('addon.nodes.group_instance'), inst_mod.__dict__)
+sys.modules['addon.nodes.group_instance'] = inst_mod
+
+
+class FakeSocket:
+    def __init__(self, name, bl_idname, is_output=False):
+        self.name = name
+        self.bl_idname = bl_idname
+        self.is_output = is_output
+        self.links = []
+        self.is_linked = False
+        self.node = None
+        self.value = None
+        self.link_limit = 1
+        self.display_shape = 'CIRCLE'
+
+    @property
+    def is_multi_input(self):
+        return self.link_limit != 1
+
+class FakeSocketList(list):
+    def __init__(self, node):
+        super().__init__()
+        self.node = node
+
+    def new(self, bl_idname, name):
+        sock = FakeSocket(name, bl_idname, is_output=self is getattr(self.node, 'outputs', None))
+        sock.node = self.node
+        self.append(sock)
+        return sock
+
+    def remove(self, sock):
+        list.remove(self, sock)
+
+    def move(self, from_index, to_index):
+        sock = self.pop(from_index)
+        self.insert(to_index, sock)
+
+    def find(self, name):
+        for i, s in enumerate(self):
+            if s.name == name:
+                return i
+        return -1
+
+    def get(self, name):
+        for s in self:
+            if s.name == name:
+                return s
+        return None
+
+class FakeLink:
+    def __init__(self, from_socket, to_socket):
+        self.from_socket = from_socket
+        self.to_socket = to_socket
+        self.from_node = from_socket.node
+        self.to_node = to_socket.node
+
+class FakeLinks(list):
+    def new(self, from_socket, to_socket):
+        link = FakeLink(from_socket, to_socket)
+        list.append(self, link)
+        from_socket.links.append(link)
+        to_socket.links.append(link)
+        to_socket.is_linked = True
+        return link
+
+    def remove(self, link):
+        if link in self:
+            list.remove(self, link)
+        if link in link.from_socket.links:
+            link.from_socket.links.remove(link)
+        if link in link.to_socket.links:
+            link.to_socket.links.remove(link)
+            link.to_socket.is_linked = bool(link.to_socket.links)
+
+class FakeInterface:
+    def __init__(self):
+        self.items_tree = []
+    def new_socket(self, name, in_out='INPUT', socket_type='FNSocketString'):
+        item = pytypes.SimpleNamespace(name=name, in_out=in_out, socket_type=socket_type)
+        self.items_tree.append(item)
+        return item
+
+class DummyInputs:
+    def __init__(self):
+        self.inputs = []
+    def sync_inputs(self, tree):
+        self.inputs = []
+        for item in tree.interface.items_tree:
+            if item.in_out == 'INPUT':
+                inp = pytypes.SimpleNamespace(name=item.name, socket_type=item.socket_type, value=None)
+                inp.prop_name = lambda n=inp: 'value'
+                self.inputs.append(inp)
+    def get_input_value(self, name):
+        for i in self.inputs:
+            if i.name == name:
+                return i.value
+        return None
+    def prepare_eval_scene(self, scene):
+        pass
+    def reset_to_originals(self):
+        pass
+
+class FakeTree:
+    bl_idname = 'FileNodesTreeType'
+    def __init__(self):
+        self.links = FakeLinks()
+        self.nodes = []
+        self.interface = FakeInterface()
+        self.fn_inputs = DummyInputs()
+
+
+def link_sockets(from_socket, to_socket, tree):
+    tree.links.new(from_socket, to_socket)
+
+
+class GroupInstanceTests(unittest.TestCase):
+    def test_basic_instance(self):
+        sub_tree = FakeTree()
+        sub_tree.interface.new_socket('Value', 'INPUT', 'FNSocketString')
+        sub_tree.interface.new_socket('Result', 'OUTPUT', 'FNSocketString')
+        sub_tree.fn_inputs.sync_inputs(sub_tree)
+
+        g_in = gi_mod.FNGroupInputNode.__new__(gi_mod.FNGroupInputNode)
+        g_in.id_data = sub_tree
+        g_in.inputs = FakeSocketList(g_in)
+        g_in.outputs = FakeSocketList(g_in)
+        g_in.init(None)
+
+        g_out = go_mod.FNGroupOutputNode.__new__(go_mod.FNGroupOutputNode)
+        g_out.id_data = sub_tree
+        g_out.inputs = FakeSocketList(g_out)
+        g_out.outputs = FakeSocketList(g_out)
+        g_out.init(None)
+
+        link_sockets(g_in.outputs[0], g_out.inputs[0], sub_tree)
+        sub_tree.nodes = [g_in, g_out]
+
+        root_tree = FakeTree()
+        node = inst_mod.FNGroupInstanceNode.__new__(inst_mod.FNGroupInstanceNode)
+        node.id_data = root_tree
+        node.inputs = FakeSocketList(node)
+        node.outputs = FakeSocketList(node)
+        node.node_tree = sub_tree
+        node._sync_sockets()
+
+        context = pytypes.SimpleNamespace(scene=None)
+        out = node.process(context, {'Value': 'Hello'})
+        self.assertEqual(out['Result'], 'Hello')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `FNGroupInstanceNode` for instantiating File Nodes groups
- register node module and expose in the add menu
- test node with a simple sub-tree
- document group instance node usage

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd0d8f878833091b06df861e3e9ca