### PR TITLE
Update multi-input nodes and defaults

### DIFF
--- a/nodes/get_item_by_index.py
+++ b/nodes/get_item_by_index.py
@@ -60,7 +60,7 @@ class FNGetItemByIndex(Node, FNBaseNode):
             ('TEXT', 'Text', ''),
             ('WORKSPACE', 'WorkSpace', ''),
         ],
-        default='WORLD',
+        default='SCENE',
         update=lambda self, context: self.update_type(context)
     )
 

--- a/nodes/get_item_by_name.py
+++ b/nodes/get_item_by_name.py
@@ -60,7 +60,7 @@ class FNGetItemByName(Node, FNBaseNode):
             ('TEXT', 'Text', ''),
             ('WORKSPACE', 'WorkSpace', ''),
         ],
-        default='WORLD',
+        default='SCENE',
         update=lambda self, context: self.update_type(context)
     )
 

--- a/nodes/index_switch.py
+++ b/nodes/index_switch.py
@@ -51,7 +51,7 @@ class FNIndexSwitch(Node, FNBaseNode):
             ('TEXT', 'Text', ''),
             ('WORKSPACE', 'WorkSpace', ''),
         ],
-        default='WORLD',
+        default='SCENE',
         update=lambda self, context: self._update_sockets(context)
     )
 

--- a/nodes/input_nodes.py
+++ b/nodes/input_nodes.py
@@ -82,6 +82,7 @@ class FNSceneInputNode(Node, FNCacheIDMixin, FNBaseNode):
     value: bpy.props.PointerProperty(type=bpy.types.Scene, update=auto_evaluate_if_enabled)
 
     def init(self, context):
+        self.inputs.new('FNSocketScene', "Scene")
         self.inputs.new('FNSocketString', "Name")
         self.outputs.new('FNSocketScene', "Scene")
 
@@ -89,7 +90,7 @@ class FNSceneInputNode(Node, FNCacheIDMixin, FNBaseNode):
         layout.prop(self, "value", text="Scene")
 
     def process(self, context, inputs):
-        scene = self.value
+        scene = inputs.get("Scene") or self.value
         if not scene:
             return {"Scene": None}
         name = inputs.get("Name") or scene.name

--- a/nodes/switch.py
+++ b/nodes/switch.py
@@ -44,7 +44,7 @@ class FNSwitch(Node, FNBaseNode):
             ('TEXT', 'Text', ''),
             ('WORKSPACE', 'WorkSpace', ''),
         ],
-        default='WORLD',
+        default='SCENE',
         update=lambda self, context: self.update_type(context)
     )
 

--- a/tests/test_dynamic_sockets.py
+++ b/tests/test_dynamic_sockets.py
@@ -162,7 +162,7 @@ class DynamicSocketTests(unittest.TestCase):
         node.inputs = FakeSocketList(node)
         node.outputs = FakeSocketList(node)
         if hasattr(cls, 'data_type') or 'data_type' in getattr(cls, '__annotations__', {}):
-            object.__setattr__(node, 'data_type', 'WORLD')
+            object.__setattr__(node, 'data_type', 'SCENE')
         if 'input_count' in getattr(cls, '__annotations__', {}):
             object.__setattr__(node, 'input_count', 2)
         if hasattr(cls, 'separator'):
@@ -174,13 +174,14 @@ class DynamicSocketTests(unittest.TestCase):
 
     def test_join_strings_multi_input(self):
         node, _ = self._setup_node(join_mod.FNJoinStrings)
-        self.assertEqual(len(node.inputs), 1)
-        sock = node.inputs[0]
-        self.assertEqual(sock.link_limit, 0)
-        self.assertEqual(sock.display_shape, 'CIRCLE_DOT')
+        self.assertEqual(len(node.inputs), 2)
+        node.input_count = 3
+        node._update_sockets()
+        self.assertEqual(len(node.inputs), 3)
 
         node.separator = ''
-        result = node.process(None, {"String": ["A", "B", "C"]})
+        inputs = {f"String {i}": v for i, v in enumerate(["A", "B", "C"])}
+        result = node.process(None, inputs)
         self.assertEqual(result["String"], "ABC")
 
     def test_switch_basic(self):

--- a/tests/test_scene_input_duplicate.py
+++ b/tests/test_scene_input_duplicate.py
@@ -139,12 +139,15 @@ class SceneInputDuplicateTest(unittest.TestCase):
         tree = tree_mod.FileNodesTree.__new__(tree_mod.FileNodesTree)
         node = ins.FNSceneInputNode.__new__(ins.FNSceneInputNode)
         node.id_data = tree
-        node.inputs = [FakeSocket("Name", "FNSocketString")]
+        node.inputs = [
+            FakeSocket("Scene", "FNSocketScene"),
+            FakeSocket("Name", "FNSocketString")
+        ]
         node.outputs = [FakeSocket("Scene", "FNSocketScene", True)]
         for s in node.inputs + node.outputs:
             s.node = node
         node.value = _DummyScene("Base")
-        node.inputs[0].value = "Copy"
+        node.inputs[1].value = "Copy"
 
         out = DummyOutputNode()
         link_sockets(node.outputs[0], out.inputs[0])


### PR DESCRIPTION
## Summary
- add `input_count` property and dynamic sockets to Join Strings and Create List
- change data selector defaults from `World` to `Scene`
- allow `Scene` to be connected in Scene Input node
- update tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e4cd540e083308e274205983d96f4