### PR TITLE
Add input count controls to Join Strings and Create List nodes

### DIFF
--- a/nodes/create_list.py
+++ b/nodes/create_list.py
@@ -97,6 +97,7 @@ class FNCreateList(Node, FNBaseNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "data_type", text="Type")
+        layout.prop(self, "input_count", text="Inputs")
 
     def process(self, context, inputs):
         output_name = f"{self.data_type.title()}s"

--- a/nodes/join_strings.py
+++ b/nodes/join_strings.py
@@ -25,6 +25,7 @@ class FNJoinStrings(Node, FNBaseNode):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "separator", text="Separator")
+        layout.prop(self, "input_count", text="Inputs")
 
     def process(self, context, inputs):
         parts = []


### PR DESCRIPTION
## Summary
- expose the **Inputs** parameter in Join Strings and Create List nodes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e4e8eeee08330b66a878bdc2ea071