### PR TITLE
Update UI panel to list group interface inputs

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -25,18 +25,26 @@ class FILE_NODES_PT_global(Panel):
         )
 
         tree = scene.file_nodes_tree
-        if tree and getattr(tree, "fn_inputs", None):
+        iface = getattr(tree, "interface", None)
+        ctx = getattr(tree, "fn_inputs", None)
+        if tree and iface and ctx:
+            ctx.sync_inputs(tree)
             box = layout.box()
-            for inp in tree.fn_inputs.inputs:
-                prop = inp.prop_name()
-                if prop:
-                    box.prop(inp, prop, text=inp.name)
+            if hasattr(box, "template_node_view"):
+                box.template_node_view(tree, None, None)
+            for item in iface.items_tree:
+                if getattr(item, "in_out", None) == 'INPUT':
+                    inp = ctx.inputs.get(item.name)
+                    if inp:
+                        prop = inp.prop_name()
+                        if prop:
+                            box.prop(inp, prop, text=item.name)
 
 
 def _tree_prop_update(self, context):
     tree = self.file_nodes_tree
-    if tree and getattr(tree, "fn_inputs", None):
-        tree.fn_inputs.sync_inputs(tree)
+    if tree:
+        tree.interface_update(context)
 
 
 def register():


### PR DESCRIPTION
## Summary
- adjust panel to pull input sockets from node group interface rather than `tree.fn_inputs`
- sync inputs using the tree's interface update
- call `layout.template_node_view` when available to mimic node group UIs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f1f772e088330af606f8700af2913