### PR TITLE
Fix NodeSocket.draw_color registration error

### DIFF
--- a/sockets.py
+++ b/sockets.py
@@ -20,8 +20,7 @@ class FNSocketBool(NodeSocket):
     bl_label = "Boolean"
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'CHECKBOX_HLT')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.8, 0.8, 0.2)
     value: bpy.props.BoolProperty(update=auto_evaluate_if_enabled)
 
@@ -30,8 +29,7 @@ class FNSocketFloat(NodeSocket):
     bl_label = "Float"
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'PROP_FLOAT')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.6, 0.8, 0.9)
     value: bpy.props.FloatProperty(update=auto_evaluate_if_enabled)
 
@@ -40,8 +38,7 @@ class FNSocketInt(NodeSocket):
     bl_label = "Integer"
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'SORTSIZE')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.9, 0.7, 0.5)
     value: bpy.props.IntProperty(update=auto_evaluate_if_enabled)
 
@@ -50,8 +47,7 @@ class FNSocketString(NodeSocket):
     bl_label = "String"
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text)
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.7, 0.7, 0.7)
     value: bpy.props.StringProperty(update=auto_evaluate_if_enabled)
 
@@ -61,8 +57,7 @@ class FNSocketStringList(NodeSocket):
     display_shape = 'SQUARE'
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='FONT_DATA')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.7, 0.7, 0.7)
 
 # Single datablock sockets
@@ -71,8 +66,7 @@ class FNSocketScene(NodeSocket):
     bl_label = "Scene"
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='SCENE_DATA')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.6, 0.9, 1.0)
     value: bpy.props.PointerProperty(type=bpy.types.Scene, update=auto_evaluate_if_enabled)
 
@@ -90,8 +84,7 @@ class FNSocketObject(NodeSocket):
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'OBJECT_DATA')
     # Use Blender's default orange object socket color
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.93, 0.62, 0.36)
     value: bpy.props.PointerProperty(type=bpy.types.Object, update=auto_evaluate_if_enabled)
 
@@ -101,8 +94,7 @@ class FNSocketCollection(NodeSocket):
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'OUTLINER_COLLECTION')
     # Blender's default collection socket color is white
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.96, 0.96, 0.96)
     value: bpy.props.PointerProperty(type=bpy.types.Collection, update=auto_evaluate_if_enabled)
 
@@ -111,8 +103,7 @@ class FNSocketCamera(NodeSocket):
     bl_label = "Camera"
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'CAMERA_DATA')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.8, 0.6, 0.4)
     value: bpy.props.PointerProperty(type=bpy.types.Camera, update=auto_evaluate_if_enabled)
 
@@ -121,8 +112,7 @@ class FNSocketImage(NodeSocket):
     bl_label = "Image"
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'IMAGE_DATA')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.8, 0.8, 0.8)
     value: bpy.props.PointerProperty(type=bpy.types.Image, update=auto_evaluate_if_enabled)
 
@@ -131,8 +121,7 @@ class FNSocketLight(NodeSocket):
     bl_label = "Light"
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'LIGHT_DATA')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(1.0, 0.9, 0.3)
     value: bpy.props.PointerProperty(type=bpy.types.Light, update=auto_evaluate_if_enabled)
 
@@ -141,8 +130,7 @@ class FNSocketMaterial(NodeSocket):
     bl_label = "Material"
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'MATERIAL_DATA')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.9, 0.6, 0.8)
     value: bpy.props.PointerProperty(type=bpy.types.Material, update=auto_evaluate_if_enabled)
 
@@ -152,8 +140,7 @@ class FNSocketMesh(NodeSocket):
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'MESH_DATA')
     # Match geometry socket color used in Geometry Nodes (green)
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.0, 0.84, 0.64)
     value: bpy.props.PointerProperty(type=bpy.types.Mesh, update=auto_evaluate_if_enabled)
 
@@ -162,8 +149,7 @@ class FNSocketNodeTree(NodeSocket):
     bl_label = "Node Tree"
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'NODETREE')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.7, 0.9, 0.7)
     value: bpy.props.PointerProperty(type=bpy.types.NodeTree, update=auto_evaluate_if_enabled)
 
@@ -172,8 +158,7 @@ class FNSocketText(NodeSocket):
     bl_label = "Text"
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'TEXT')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.9, 0.9, 0.6)
     value: bpy.props.PointerProperty(type=bpy.types.Text, update=auto_evaluate_if_enabled)
 
@@ -182,8 +167,7 @@ class FNSocketWorkSpace(NodeSocket):
     bl_label = "WorkSpace"
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'WORKSPACE')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.5, 0.7, 0.9)
     value: bpy.props.PointerProperty(type=bpy.types.WorkSpace, update=auto_evaluate_if_enabled)
 
@@ -192,8 +176,7 @@ class FNSocketWorld(NodeSocket):
     bl_label = "World"
     def draw(self, context, layout, node, text):
         _draw_value_socket(self, layout, text, 'WORLD')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.8, 0.8, 0.3)
     value: bpy.props.PointerProperty(type=bpy.types.World, update=auto_evaluate_if_enabled)
 
@@ -204,8 +187,7 @@ class FNSocketSceneList(NodeSocket):
     display_shape = 'SQUARE'
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='SCENE_DATA')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.6, 0.9, 1.0)
 
 class FNSocketObjectList(NodeSocket):
@@ -214,8 +196,7 @@ class FNSocketObjectList(NodeSocket):
     display_shape = 'SQUARE'
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='OBJECT_DATA')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.93, 0.62, 0.36)
 
 class FNSocketCollectionList(NodeSocket):
@@ -224,8 +205,7 @@ class FNSocketCollectionList(NodeSocket):
     display_shape = 'SQUARE'
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='OUTLINER_COLLECTION')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.96, 0.96, 0.96)
 
 class FNSocketWorldList(NodeSocket):
@@ -234,8 +214,7 @@ class FNSocketWorldList(NodeSocket):
     display_shape = 'SQUARE'
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='WORLD')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.8, 0.8, 0.3)
 
 class FNSocketCameraList(NodeSocket):
@@ -244,8 +223,7 @@ class FNSocketCameraList(NodeSocket):
     display_shape = 'SQUARE'
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='CAMERA_DATA')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.8, 0.6, 0.4)
 
 class FNSocketImageList(NodeSocket):
@@ -254,8 +232,7 @@ class FNSocketImageList(NodeSocket):
     display_shape = 'SQUARE'
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='IMAGE_DATA')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.8, 0.8, 0.8)
 
 class FNSocketLightList(NodeSocket):
@@ -264,8 +241,7 @@ class FNSocketLightList(NodeSocket):
     display_shape = 'SQUARE'
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='LIGHT_DATA')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(1.0, 0.9, 0.3)
 
 class FNSocketMaterialList(NodeSocket):
@@ -274,8 +250,7 @@ class FNSocketMaterialList(NodeSocket):
     display_shape = 'SQUARE'
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='MATERIAL_DATA')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.9, 0.6, 0.8)
 
 class FNSocketMeshList(NodeSocket):
@@ -284,8 +259,7 @@ class FNSocketMeshList(NodeSocket):
     display_shape = 'SQUARE'
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='MESH_DATA')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.0, 0.84, 0.64)
 
 class FNSocketNodeTreeList(NodeSocket):
@@ -294,8 +268,7 @@ class FNSocketNodeTreeList(NodeSocket):
     display_shape = 'SQUARE'
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='NODETREE')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.7, 0.9, 0.7)
 
 class FNSocketTextList(NodeSocket):
@@ -304,8 +277,7 @@ class FNSocketTextList(NodeSocket):
     display_shape = 'SQUARE'
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='TEXT')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.9, 0.9, 0.6)
 
 class FNSocketWorkSpaceList(NodeSocket):
@@ -314,8 +286,7 @@ class FNSocketWorkSpaceList(NodeSocket):
     display_shape = 'SQUARE'
     def draw(self, context, layout, node, text):
         layout.label(text=text or self.name, icon='WORKSPACE')
-    @classmethod
-    def draw_color(cls, context, node):
+    def draw_color(self, context, node):
         return _color(0.5, 0.7, 0.9)
 
 _all_sockets = (


### PR DESCRIPTION
## Summary
- remove `@classmethod` decorator from socket `draw_color`
- adjust to instance method to satisfy Blender's register_class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2587303883309d9f3c19a877e979