### PR TITLE
Add Vector socket and Vector Input node

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -89,6 +89,7 @@ categories = [
         NodeItem('FNFloatInputNode'),
         NodeItem('FNIntInputNode'),
         NodeItem('FNStringInputNode'),
+        NodeItem('FNVectorInputNode'),
     ]),
 ]
 

--- a/nodes/input_nodes.py
+++ b/nodes/input_nodes.py
@@ -4,7 +4,7 @@ from ..operators import auto_evaluate_if_enabled
 
 from .base import FNBaseNode, FNCacheIDMixin
 from ..sockets import (
-    FNSocketBool, FNSocketFloat, FNSocketInt, FNSocketString,
+    FNSocketBool, FNSocketFloat, FNSocketVector, FNSocketInt, FNSocketString,
     FNSocketScene, FNSocketObject, FNSocketCollection, FNSocketWorld,
     FNSocketCamera, FNSocketImage, FNSocketLight, FNSocketMaterial,
     FNSocketMesh, FNSocketNodeTree, FNSocketText, FNSocketWorkSpace,
@@ -73,6 +73,22 @@ class FNStringInputNode(Node, FNBaseNode):
 
     def process(self, context, inputs):
         return {"String": self.value}
+
+
+class FNVectorInputNode(Node, FNBaseNode):
+    bl_idname = "FNVectorInputNode"
+    bl_label = "Vector Input"
+
+    value: bpy.props.FloatVectorProperty(name="Value", size=3, update=auto_evaluate_if_enabled)
+
+    def init(self, context):
+        self.outputs.new('FNSocketVector', "Vector")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "value", text="")
+
+    def process(self, context, inputs):
+        return {"Vector": self.value}
 
 
 class FNSceneInputNode(Node, FNCacheIDMixin, FNBaseNode):
@@ -281,6 +297,7 @@ class FNWorkSpaceInputNode(Node, FNBaseNode):
 
 _classes = (
     FNBoolInputNode, FNFloatInputNode, FNIntInputNode, FNStringInputNode,
+    FNVectorInputNode,
     FNSceneInputNode, FNObjectInputNode, FNCollectionInputNode,
     FNWorldInputNode, FNCameraInputNode, FNImageInputNode, FNLightInputNode, FNMaterialInputNode,
     FNMeshInputNode, FNNodeTreeInputNode, FNTextInputNode, FNWorkSpaceInputNode,

--- a/sockets.py
+++ b/sockets.py
@@ -33,6 +33,15 @@ class FNSocketFloat(NodeSocket):
         return _color(0.6, 0.8, 0.9)
     value: bpy.props.FloatProperty(update=auto_evaluate_if_enabled)
 
+class FNSocketVector(NodeSocket):
+    bl_idname = "FNSocketVector"
+    bl_label = "Vector"
+    def draw(self, context, layout, node, text):
+        _draw_value_socket(self, layout, text)
+    def draw_color(self, context, node):
+        return _color(0.4, 0.7, 0.9)
+    value: bpy.props.FloatVectorProperty(size=3, update=auto_evaluate_if_enabled)
+
 class FNSocketInt(NodeSocket):
     bl_idname = "FNSocketInt"
     bl_label = "Integer"
@@ -283,7 +292,8 @@ class FNSocketWorkSpaceList(NodeSocket):
         return _color(0.5, 0.7, 0.9)
 
 _all_sockets = (
-    FNSocketBool, FNSocketFloat, FNSocketInt, FNSocketString, FNSocketStringList,
+    FNSocketBool, FNSocketFloat, FNSocketVector, FNSocketInt,
+    FNSocketString, FNSocketStringList,
     FNSocketScene, FNSocketObject, FNSocketCollection, FNSocketWorld,
     FNSocketCamera, FNSocketImage, FNSocketLight, FNSocketMaterial,
     FNSocketMesh, FNSocketNodeTree, FNSocketText, FNSocketWorkSpace,

--- a/tests/test_vector_input.py
+++ b/tests/test_vector_input.py
@@ -1,0 +1,89 @@
+import types as pytypes
+import sys
+import importlib.util
+from pathlib import Path
+import unittest
+
+# Minimal fake bpy module
+_bpy = pytypes.ModuleType('bpy')
+
+class _Props:
+    def __getattr__(self, name):
+        def _f(*a, **kw):
+            return None
+        return _f
+
+_bpy.props = _Props()
+
+class _Types:
+    class Node: pass
+    class Scene: pass
+    class Object: pass
+    class Collection: pass
+    class World: pass
+    class Camera: pass
+    class Image: pass
+    class Light: pass
+    class Material: pass
+    class Mesh: pass
+    class NodeTree: pass
+    class Text: pass
+    class WorkSpace: pass
+
+_bpy.types = _Types()
+_bpy.utils = pytypes.SimpleNamespace(register_class=lambda c: None, unregister_class=lambda c: None)
+_bpy.data = pytypes.SimpleNamespace(node_groups=[])
+_bpy.__path__ = []
+
+sys.modules['bpy'] = _bpy
+sys.modules['bpy.types'] = _bpy.types
+
+# Fake addon package hierarchy
+_addon = pytypes.ModuleType('addon')
+_addon.__path__ = ['.']
+_addon.ADDON_NAME = 'addon'
+sys.modules['addon'] = _addon
+_nodes_pkg = pytypes.ModuleType('addon.nodes')
+_nodes_pkg.__path__ = ['nodes']
+sys.modules['addon.nodes'] = _nodes_pkg
+
+# Fake sockets module with required classes
+_sockets = pytypes.ModuleType('addon.sockets')
+_socket_names = [
+    'FNSocketBool', 'FNSocketFloat', 'FNSocketVector', 'FNSocketInt', 'FNSocketString',
+    'FNSocketScene', 'FNSocketObject', 'FNSocketCollection', 'FNSocketWorld',
+    'FNSocketCamera', 'FNSocketImage', 'FNSocketLight', 'FNSocketMaterial',
+    'FNSocketMesh', 'FNSocketNodeTree', 'FNSocketText', 'FNSocketWorkSpace',
+]
+for name in _socket_names:
+    setattr(_sockets, name, type(name, (), {}))
+sys.modules['addon.sockets'] = _sockets
+
+# Load the input_nodes module
+spec = importlib.util.spec_from_file_location(
+    'addon.nodes.input_nodes', Path('nodes/input_nodes.py'),
+    submodule_search_locations=['nodes']
+)
+input_mod = importlib.util.module_from_spec(spec)
+input_mod.__package__ = 'addon.nodes'
+exec(spec.loader.get_code('addon.nodes.input_nodes'), input_mod.__dict__)
+sys.modules['addon.nodes.input_nodes'] = input_mod
+
+
+class VectorInputTest(unittest.TestCase):
+    def test_basic(self):
+        cls = input_mod.FNVectorInputNode
+        node = cls.__new__(cls)
+        node.outputs = []
+        node.id_data = None
+        node.outputs = type('FakeList', (), {
+            'new': lambda self, idname, name: None
+        })()
+        node.init(None)
+        node.value = (1.0, 2.0, 3.0)
+        out = node.process(None, {})
+        self.assertEqual(out['Vector'], (1.0, 2.0, 3.0))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- support Vector socket type for 3D float vectors
- implement `FNVectorInputNode` with a FloatVector property
- expose Vector Input in node menu
- test Vector Input node

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fba8366448330b97e80fc7d4fc44b