### PR TITLE
Fix missing XYZ nodes in Add menu

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -17,6 +17,8 @@ categories = [
         NodeItem('FNGetItemByIndex'),
         NodeItem('FNJoinStrings'),
         NodeItem('FNSplitString'),
+        NodeItem('FNCombineXYZ'),
+        NodeItem('FNSeparateXYZ'),
         NodeItem('FNSwitch'),
         NodeItem('FNIndexSwitch'),
     ]),


### PR DESCRIPTION
## Summary
- ensure Combine and Separate XYZ nodes appear in the Add menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fcb18b5a88330920b36fc93535b01