### PR TITLE
Set node header color

### DIFF
--- a/nodes/base.py
+++ b/nodes/base.py
@@ -22,8 +22,28 @@ class FNCacheIDMixin:
         self._cached_id = None
 
 class FNBaseNode:
-    '''Mixin to add a .process(context, inputs) stub'''
+    '''Mixin to add a .process(context, inputs) stub and default node color.'''
+
+    DEFAULT_COLOR = (0.2, 0.2, 0.2)
+
     bl_width_default = 160
+
+    def __init_subclass__(cls) -> None:  # pragma: no cover - executed at import
+        """Ensure subclasses apply the default header color."""
+        super().__init_subclass__()
+        original_init = getattr(cls, "init", None)
+
+        def _init(self, context):
+            if original_init:
+                original_init(self, context)
+            try:
+                self.use_custom_color = True
+                self.color = cls.DEFAULT_COLOR
+            except Exception:
+                pass
+
+        cls.init = _init
+
     def process(self, context, inputs):
         return {}
 


### PR DESCRIPTION
## Summary
- add default node header color mixin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685feab10e1c8330b63e2ffe7c320008