### PR TITLE
Update node header color

### DIFF
--- a/nodes/base.py
+++ b/nodes/base.py
@@ -22,8 +22,11 @@ class FNCacheIDMixin:
         self._cached_id = None
 
 class FNBaseNode:
-    '''Mixin to add a .process(context, inputs) stub'''
+    '''Mixin to add a .process(context, inputs) stub and default header color.'''
     bl_width_default = 160
+    # Default header color for all nodes
+    bl_color = (0.2, 0.2, 0.2)
+
     def process(self, context, inputs):
         return {}
 


### PR DESCRIPTION
## Summary
- tweak base node definition so all nodes use a dark header color

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685feab10e1c8330b63e2ffe7c320008