### PR TITLE
Prevent recursive group evaluation

### DIFF
--- a/nodes/group.py
+++ b/nodes/group.py
@@ -1,4 +1,5 @@
 import bpy
+import warnings
 from bpy.types import NodeCustomGroup
 from .base import FNBaseNode
 from .. import operators
@@ -63,6 +64,15 @@ class FNGroupNode(NodeCustomGroup, FNBaseNode):
         tree = self.node_tree
         if not tree:
             return {s.name: None for s in self.outputs}
+
+        id_tree = getattr(self, "id_data", None)
+        if hasattr(id_tree, "contains_tree"):
+            try:
+                if id_tree.contains_tree(tree) and hasattr(tree, "contains_tree") and tree.contains_tree(id_tree):
+                    warnings.warn("Group recursion detected; skipping evaluation")
+                    return {s.name: None for s in self.outputs}
+            except Exception:
+                pass
 
         ctx = getattr(tree, "fn_inputs", None)
         if ctx:

--- a/tests/test_group_node.py
+++ b/tests/test_group_node.py
@@ -214,6 +214,27 @@ class FakeTree:
         self.interface = FakeInterface()
         self.fn_inputs = DummyInputs()
 
+    def contains_tree(self, sub_tree):
+        if not sub_tree:
+            return False
+
+        visited = set()
+
+        def walk(tree):
+            if tree == sub_tree:
+                return True
+            if tree in visited:
+                return False
+            visited.add(tree)
+            for node in getattr(tree, "nodes", []):
+                if getattr(node, "bl_idname", "") == "FNGroupNode":
+                    child = getattr(node, "node_tree", None)
+                    if child and walk(child):
+                        return True
+            return False
+
+        return walk(self)
+
 
 def link_sockets(from_socket, to_socket, tree):
     tree.links.new(from_socket, to_socket)
@@ -248,6 +269,34 @@ class GroupInstanceTests(unittest.TestCase):
         context = pytypes.SimpleNamespace(scene=None)
         out = node.process(context, {'Value': 'Hello'})
         self.assertEqual(out['Result'], 'Hello')
+
+    def test_recursion_prevention(self):
+        tree = FakeTree()
+        tree.interface.new_socket('Value', 'INPUT', 'FNSocketString')
+        tree.interface.new_socket('Result', 'OUTPUT', 'FNSocketString')
+        tree.fn_inputs.sync_inputs(tree)
+
+        g_in = NodeGroupInput()
+        g_in.id_data = tree
+        g_in.init(None)
+
+        g_out = NodeGroupOutput()
+        g_out.id_data = tree
+        g_out.init(None)
+
+        link_sockets(g_in.outputs[0], g_out.inputs[0], tree)
+        tree.nodes = [g_in, g_out]
+
+        node = group_mod.FNGroupNode.__new__(group_mod.FNGroupNode)
+        node.id_data = tree
+        node.inputs = FakeSocketList(node)
+        node.outputs = FakeSocketList(node)
+        node.node_tree = tree  # self-reference
+        node._sync_sockets()
+
+        context = pytypes.SimpleNamespace(scene=None)
+        out = node.process(context, {'Value': 'Hello'})
+        self.assertIsNone(out['Result'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- detect recursion before evaluating a `FNGroupNode`
- warn and skip evaluation when groups reference themselves
- test that a self-referencing group does not recurse

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686004cd4af0833090f614d329ea81d1