### PR TITLE
Fix Blender API compatibility

### DIFF
--- a/tree.py
+++ b/tree.py
@@ -204,7 +204,7 @@ class FileNodesTree(NodeTree):
     fn_enabled: bpy.props.BoolProperty(name='Enabled', default=True)
     fn_inputs: bpy.props.PointerProperty(type=FileNodesTreeInputs)
 
-    def interface_update(self, context=None):
+    def interface_update(self, context):
         if getattr(self, "fn_inputs", None):
             self.fn_inputs.sync_inputs(self)
 
@@ -250,7 +250,7 @@ class FileNodesTree(NodeTree):
         return walk(self)
 
     def update(self):
-        self.interface_update()
+        self.interface_update(bpy.context)
         if getattr(self, "fn_inputs", None):
             self.fn_inputs.restore_and_clear()
 

--- a/ui.py
+++ b/ui.py
@@ -31,7 +31,7 @@ class FILE_NODES_PT_global(Panel):
             ctx.sync_inputs(tree)
             box = layout.box()
             if hasattr(box, "template_node_view") and iface:
-                box.template_node_view(context, tree, None, None)
+                box.template_node_view(tree, None, None)
             for item in getattr(iface, "items_tree", []):
                 if getattr(item, "in_out", None) == 'INPUT':
                     inp = ctx.inputs.get(item.name)


### PR DESCRIPTION
## Summary
- update `interface_update` method signature
- call `interface_update` with context from `update`
- remove deprecated context argument from `template_node_view`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686006a5305883309c86d84b9508b088