### PR TITLE
Fix crash in UI draw when template_node_view used

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -31,7 +31,12 @@ class FILE_NODES_PT_global(Panel):
             ctx.sync_inputs(tree)
             box = layout.box()
             if hasattr(box, "template_node_view") and iface:
-                box.template_node_view(tree, None, None)
+                node = tree.nodes.active
+                socket = None
+                if node:
+                    socket = node.outputs[0] if node.outputs else (node.inputs[0] if node.inputs else None)
+                if node and socket:
+                    box.template_node_view(tree, node, socket)
             for item in getattr(iface, "items_tree", []):
                 if getattr(item, "in_out", None) == 'INPUT':
                     inp = ctx.inputs.get(item.name)


### PR DESCRIPTION
## Summary
- guard `template_node_view` call with active node and socket

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68601222f734833099894cb8603e83d7