### PR TITLE
Fix crash on invalid socket type name

### DIFF
--- a/tree.py
+++ b/tree.py
@@ -232,6 +232,8 @@ class FileNodesTree(NodeTree):
         e.g. while dragging a link.  The new version falls back to any
         type present in ``bpy.types``.
         """
+        if not idname:
+            return False
         try:
             from . import sockets
             if hasattr(sockets, idname):


### PR DESCRIPTION
## Summary
- prevent `FileNodesTree.valid_socket_type` from raising errors when Blender queries with an empty socket type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68601a4799708330acf5c45f39b888ae