### PR TITLE
Handle additional builtin socket types

### DIFF
--- a/tests/test_tree_utils.py
+++ b/tests/test_tree_utils.py
@@ -29,6 +29,7 @@ class _Types:
     class Mesh: pass
     class Text: pass
     class WorkSpace: pass
+    class NodeSocketFloat: pass
 
 _bpy.types = _Types()
 _bpy.utils = pytypes.SimpleNamespace(register_class=lambda c: None, unregister_class=lambda c: None)
@@ -80,6 +81,7 @@ class TreeUtilsTests(unittest.TestCase):
         cls = tree_mod.FileNodesTree
         self.assertTrue(cls.valid_socket_type('FNSocketString'))
         self.assertTrue(cls.valid_socket_type('NodeSocketVirtual'))
+        self.assertTrue(cls.valid_socket_type('NodeSocketFloat'))
         self.assertFalse(cls.valid_socket_type('NotASocket'))
 
 

--- a/tree.py
+++ b/tree.py
@@ -240,9 +240,12 @@ class FileNodesTree(NodeTree):
                 return True
         except Exception:
             pass
-        if hasattr(getattr(bpy, "types", None), idname):
+        types_mod = getattr(bpy, "types", None)
+        if types_mod and hasattr(types_mod, idname):
             return True
-        return idname == "NodeSocketVirtual"
+        if idname.startswith("NodeSocket"):
+            return True
+        return False
 
     def contains_tree(self, sub_tree):
         if not sub_tree:


### PR DESCRIPTION
## Summary
- improve `valid_socket_type` logic to accept any idname starting with `NodeSocket`
- extend tree utils test coverage for builtin sockets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68601b731bc483309b1e1db9cca83cb9