### PR TITLE
Fix ID write during UI draw

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -28,7 +28,6 @@ class FILE_NODES_PT_global(Panel):
         iface = getattr(tree, "interface", None)
         ctx = getattr(tree, "fn_inputs", None)
         if tree and iface and ctx:
-            ctx.sync_inputs(tree)
             box = layout.box()
             if hasattr(box, "template_node_view") and iface:
                 box.template_node_view(context, tree, None, None)


### PR DESCRIPTION
## Summary
- avoid modifying FileNodesTree inputs inside the draw function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68601fa90fb48330bd413116d2d40a0c