### PR TITLE
Fix node tree panel crash on empty tree

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -29,7 +29,7 @@ class FILE_NODES_PT_global(Panel):
         ctx = getattr(tree, "fn_inputs", None)
         if tree and iface and ctx:
             box = layout.box()
-            if hasattr(box, "template_node_view") and iface:
+            if hasattr(box, "template_node_view") and iface and tree.nodes:
                 # Blender 4.4 switched `template_node_view` to take three
                 # arguments: `(node_tree, node, socket)`. Older versions still
                 # expect a `context` argument first. Try the old signature and


### PR DESCRIPTION
## Summary
- guard against empty node groups when calling `template_node_view`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860232551f483309a4e521ad70181b3