### PR TITLE
Fix Blender panel crash in ui draw

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -32,12 +32,12 @@ class FILE_NODES_PT_global(Panel):
             if hasattr(box, "template_node_view") and iface and tree.nodes:
                 # Blender 4.4 switched `template_node_view` to take three
                 # arguments: `(node_tree, node, socket)`. Older versions still
-                # expect a `context` argument first. Try the old signature and
-                # fall back to the new one to keep compatibility.
+                # expect a `context` argument first. Call the new signature
+                # and fall back to the old one to keep compatibility.
                 try:
-                    box.template_node_view(context, tree, None, None)
-                except TypeError:
                     box.template_node_view(tree, None, None)
+                except TypeError:
+                    box.template_node_view(context, tree, None, None)
             for item in getattr(iface, "items_tree", []):
                 if getattr(item, "in_out", None) == 'INPUT':
                     inp = ctx.inputs.get(item.name)


### PR DESCRIPTION
## Summary
- call `template_node_view` with new argument order first
- keep compatibility with older Blender versions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686025a557a88330b0e0c045571f50a9