### PR TITLE
Fix index switch socket naming

### DIFF
--- a/nodes/index_switch.py
+++ b/nodes/index_switch.py
@@ -64,7 +64,7 @@ class FNIndexSwitch(Node, FNBaseNode):
         single = _socket_single[self.data_type]
         count = max(1, int(self.input_count))
         for i in range(count):
-            self.inputs.new(single, f"{i}")
+            self.inputs.new(single, f"Value {i}")
         self.outputs.new(single, self.data_type.title())
         if context is not None:
             auto_evaluate_if_enabled(context)


### PR DESCRIPTION
## Summary
- keep the Index Switch node inputs meaningful
- create `Value i` sockets rather than unnamed indices

## Testing
- `python -m py_compile nodes/index_switch.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68602e58fc8c833094ea96a733ae2f42