### PR TITLE
Centralize LIST_TO_SINGLE dictionary

### DIFF
--- a/common.py
+++ b/common.py
@@ -1,0 +1,17 @@
+"""Common utilities and shared constants for the File Nodes addon."""
+
+LIST_TO_SINGLE = {
+    "FNSocketSceneList": "FNSocketScene",
+    "FNSocketObjectList": "FNSocketObject",
+    "FNSocketCollectionList": "FNSocketCollection",
+    "FNSocketWorldList": "FNSocketWorld",
+    "FNSocketCameraList": "FNSocketCamera",
+    "FNSocketImageList": "FNSocketImage",
+    "FNSocketLightList": "FNSocketLight",
+    "FNSocketMaterialList": "FNSocketMaterial",
+    "FNSocketMeshList": "FNSocketMesh",
+    "FNSocketNodeTreeList": "FNSocketNodeTree",
+    "FNSocketStringList": "FNSocketString",
+    "FNSocketTextList": "FNSocketText",
+    "FNSocketWorkSpaceList": "FNSocketWorkSpace",
+}

--- a/nodes/group.py
+++ b/nodes/group.py
@@ -2,6 +2,7 @@ import bpy
 from bpy.types import NodeCustomGroup
 from .base import FNBaseNode
 from .. import operators
+from ..common import LIST_TO_SINGLE
 
 
 class FNGroupNode(NodeCustomGroup, FNBaseNode):
@@ -74,27 +75,12 @@ class FNGroupNode(NodeCustomGroup, FNBaseNode):
         operators._evaluate_tree(tree, context)
 
         resolved = {}
-        _list_to_single = {
-            "FNSocketSceneList": "FNSocketScene",
-            "FNSocketObjectList": "FNSocketObject",
-            "FNSocketCollectionList": "FNSocketCollection",
-            "FNSocketWorldList": "FNSocketWorld",
-            "FNSocketCameraList": "FNSocketCamera",
-            "FNSocketImageList": "FNSocketImage",
-            "FNSocketLightList": "FNSocketLight",
-            "FNSocketMaterialList": "FNSocketMaterial",
-            "FNSocketMeshList": "FNSocketMesh",
-            "FNSocketNodeTreeList": "FNSocketNodeTree",
-            "FNSocketStringList": "FNSocketString",
-            "FNSocketTextList": "FNSocketText",
-            "FNSocketWorkSpaceList": "FNSocketWorkSpace",
-        }
 
         def eval_socket(sock):
             if not sock:
                 return None
             if sock.is_linked and getattr(sock, "links", None):
-                single = _list_to_single.get(sock.bl_idname)
+                single = LIST_TO_SINGLE.get(sock.bl_idname)
                 if getattr(sock, "is_multi_input", False):
                     values = []
                     for link in sock.links:

--- a/operators.py
+++ b/operators.py
@@ -1,6 +1,7 @@
 import bpy
 from bpy.types import Operator
 from . import ADDON_NAME
+from .common import LIST_TO_SINGLE
 
 _active_tree = None
 
@@ -83,27 +84,11 @@ class FN_OT_render_scenes(Operator):
         tree = node.id_data
         resolved = {}
 
-        _list_to_single = {
-            "FNSocketSceneList": "FNSocketScene",
-            "FNSocketObjectList": "FNSocketObject",
-            "FNSocketCollectionList": "FNSocketCollection",
-            "FNSocketWorldList": "FNSocketWorld",
-            "FNSocketCameraList": "FNSocketCamera",
-            "FNSocketImageList": "FNSocketImage",
-            "FNSocketLightList": "FNSocketLight",
-            "FNSocketMaterialList": "FNSocketMaterial",
-            "FNSocketMeshList": "FNSocketMesh",
-            "FNSocketNodeTreeList": "FNSocketNodeTree",
-            "FNSocketStringList": "FNSocketString",
-            "FNSocketTextList": "FNSocketText",
-            "FNSocketWorkSpaceList": "FNSocketWorkSpace",
-        }
-
         def eval_socket(sock):
             if sock.is_linked and sock.links:
                 from_sock = sock.links[0].from_socket
                 value = eval_node(from_sock.node)[from_sock.name]
-                single = _list_to_single.get(sock.bl_idname)
+                single = LIST_TO_SINGLE.get(sock.bl_idname)
                 if single and from_sock.bl_idname == single:
                     return [value] if value is not None else []
                 return value
@@ -174,22 +159,6 @@ def evaluate_tree(context):
 def _evaluate_tree(tree, context):
     resolved = {}
 
-    _list_to_single = {
-        "FNSocketSceneList": "FNSocketScene",
-        "FNSocketObjectList": "FNSocketObject",
-        "FNSocketCollectionList": "FNSocketCollection",
-        "FNSocketWorldList": "FNSocketWorld",
-        "FNSocketCameraList": "FNSocketCamera",
-        "FNSocketImageList": "FNSocketImage",
-        "FNSocketLightList": "FNSocketLight",
-        "FNSocketMaterialList": "FNSocketMaterial",
-        "FNSocketMeshList": "FNSocketMesh",
-        "FNSocketNodeTreeList": "FNSocketNodeTree",
-        "FNSocketStringList": "FNSocketString",
-        "FNSocketTextList": "FNSocketText",
-        "FNSocketWorkSpaceList": "FNSocketWorkSpace",
-    }
-
     output_types = {
         "FNOutputScenesNode",
         "FNRenderScenesNode",
@@ -199,7 +168,7 @@ def _evaluate_tree(tree, context):
 
     def eval_socket(sock):
         if sock.is_linked and sock.links:
-            single = _list_to_single.get(sock.bl_idname)
+            single = LIST_TO_SINGLE.get(sock.bl_idname)
             if getattr(sock, "is_multi_input", False):
                 values = []
                 for link in sock.links:


### PR DESCRIPTION
## Summary
- add a `common.py` module with the shared `LIST_TO_SINGLE` dictionary
- use this dictionary in `operators.py` and `nodes/group.py`
- remove the local copies of the dictionary

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68602eb643748330b34c55cbc5e1d786