### PR TITLE
Fix UI sync error in File Nodes

### DIFF
--- a/tree.py
+++ b/tree.py
@@ -209,6 +209,10 @@ class FileNodesTree(NodeTree):
         if getattr(self, "fn_inputs", None):
             self.fn_inputs.sync_inputs(self)
 
+    def update(self):
+        """Keep inputs in sync when the node tree changes."""
+        self.interface_update()
+
     # Poll: always available
     @classmethod
     def poll(cls, context):

--- a/ui.py
+++ b/ui.py
@@ -28,7 +28,6 @@ class FILE_NODES_PT_global(Panel):
         iface = getattr(tree, "interface", None)
         ctx = getattr(tree, "fn_inputs", None)
         if tree and iface and ctx:
-            ctx.sync_inputs(tree)
             box = layout.box()
             if hasattr(box, "template_node_view") and iface:
                 box.template_node_view(context, tree, None, None)


### PR DESCRIPTION
## Summary
- avoid calling `sync_inputs()` in the File Nodes panel draw callback
- keep `FileNodesTree` inputs in sync via `update()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860338938248330b0940aea5c8867e4