### PR TITLE
Fix FileNodesTree update signature

### DIFF
--- a/tree.py
+++ b/tree.py
@@ -205,13 +205,14 @@ class FileNodesTree(NodeTree):
     fn_enabled: bpy.props.BoolProperty(name='Enabled', default=True)
     fn_inputs: bpy.props.PointerProperty(type=FileNodesTreeInputs)
 
-    def interface_update(self, context=None):
+    def interface_update(self, context):
         if getattr(self, "fn_inputs", None):
             self.fn_inputs.sync_inputs(self)
 
     def update(self):
         """Keep inputs in sync when the node tree changes."""
-        self.interface_update()
+        if getattr(self, "fn_inputs", None):
+            self.fn_inputs.sync_inputs(self)
 
     # Poll: always available
     @classmethod

--- a/ui.py
+++ b/ui.py
@@ -30,7 +30,7 @@ class FILE_NODES_PT_global(Panel):
         if tree and iface and ctx:
             box = layout.box()
             if hasattr(box, "template_node_view") and iface:
-                box.template_node_view(context, tree, None, None)
+                box.template_node_view(tree, None, None)
             for item in getattr(iface, "items_tree", []):
                 if getattr(item, "in_out", None) == 'INPUT':
                     inp = ctx.inputs.get(item.name)


### PR DESCRIPTION
## Summary
- call UI template_node_view with correct args
- sync inputs from `update` without requiring context
- require `context` in `interface_update` to match Blender API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603526de208330a68ab66d6abd7188