### PR TITLE
Fix File Nodes panel drawing unwanted sockets

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -29,11 +29,6 @@ class FILE_NODES_PT_global(Panel):
         ctx = getattr(tree, "fn_inputs", None)
         if tree and iface and ctx:
             box = layout.box()
-            if hasattr(box, "template_node_view") and iface:
-                node = tree.nodes.active or (tree.nodes[0] if tree.nodes else None)
-                sock = node.outputs[0] if node and node.outputs else None
-                if node and sock:
-                    box.template_node_view(tree, node, sock)
             for item in getattr(iface, "items_tree", []):
                 if getattr(item, "in_out", None) == 'INPUT':
                     inp = ctx.inputs.get(item.name)


### PR DESCRIPTION
## Summary
- remove Template Node View usage from the add-on panel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68603a068e18833092e03ae3dda0eae7