### PR TITLE
Fix group input value propagation

### DIFF
--- a/nodes/group.py
+++ b/nodes/group.py
@@ -127,10 +127,13 @@ class FNGroupNode(NodeCustomGroup, FNBaseNode):
         def eval_node(node):
             if node in resolved:
                 return resolved[node]
-            node_inputs = {s.name: eval_socket(s) for s in node.inputs}
-            node_outputs = {}
-            if hasattr(node, "process"):
-                node_outputs = node.process(context, node_inputs) or {}
+            if getattr(node, "bl_idname", "") == "NodeGroupInput":
+                node_outputs = {s.name: inputs.get(s.name) for s in node.outputs}
+            else:
+                node_inputs = {s.name: eval_socket(s) for s in node.inputs}
+                node_outputs = {}
+                if hasattr(node, "process"):
+                    node_outputs = node.process(context, node_inputs) or {}
             for s in node.outputs:
                 node_outputs.setdefault(s.name, None)
             resolved[node] = node_outputs

--- a/operators.py
+++ b/operators.py
@@ -194,6 +194,17 @@ def _evaluate_tree(tree, context):
         if node in resolved:
             return resolved[node]
 
+        if getattr(node, "bl_idname", "") == "NodeGroupInput":
+            outputs = {}
+            ctx = getattr(node.id_data, "fn_inputs", None)
+            for s in node.outputs:
+                if ctx:
+                    outputs[s.name] = ctx.get_input_value(s.name)
+                else:
+                    outputs[s.name] = None
+            resolved[node] = outputs
+            return outputs
+
         inputs = {s.name: eval_socket(s) for s in node.inputs}
         outputs = {}
         if hasattr(node, "process"):


### PR DESCRIPTION
## Summary
- resolve group inputs through the tree's stored values
- ensure nested groups receive input values from the parent tree

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603c76e5d08330b47246568382d0d6