### PR TITLE
Add View Layer socket support

### DIFF
--- a/common.py
+++ b/common.py
@@ -14,4 +14,5 @@ LIST_TO_SINGLE = {
     "FNSocketStringList": "FNSocketString",
     "FNSocketTextList": "FNSocketText",
     "FNSocketWorkSpaceList": "FNSocketWorkSpace",
+    "FNSocketViewLayerList": "FNSocketViewLayer",
 }

--- a/sockets.py
+++ b/sockets.py
@@ -170,6 +170,15 @@ class FNSocketWorkSpace(NodeSocket):
         return _color(0.5, 0.7, 0.9)
     value: bpy.props.PointerProperty(type=bpy.types.WorkSpace, update=auto_evaluate_if_enabled)
 
+class FNSocketViewLayer(NodeSocket):
+    bl_idname = "FNSocketViewLayer"
+    bl_label = "View Layer"
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='RENDERLAYERS')
+    def draw_color(self, context, node):
+        return _color(0.6, 0.6, 0.6)
+    value: bpy.props.PointerProperty(type=bpy.types.ViewLayer, update=auto_evaluate_if_enabled)
+
 class FNSocketWorld(NodeSocket):
     bl_idname = "FNSocketWorld"
     bl_label = "World"
@@ -288,15 +297,26 @@ class FNSocketWorkSpaceList(NodeSocket):
     def draw_color(self, context, node):
         return _color(0.5, 0.7, 0.9)
 
+class FNSocketViewLayerList(NodeSocket):
+    bl_idname = "FNSocketViewLayerList"
+    bl_label = "View Layer List"
+    display_shape = 'SQUARE'
+    def draw(self, context, layout, node, text):
+        layout.label(text=text or self.name, icon='RENDERLAYERS')
+    def draw_color(self, context, node):
+        return _color(0.6, 0.6, 0.6)
+
 _all_sockets = (
     FNSocketBool, FNSocketFloat, FNSocketVector, FNSocketInt,
     FNSocketString, FNSocketStringList,
     FNSocketScene, FNSocketObject, FNSocketCollection, FNSocketWorld,
     FNSocketCamera, FNSocketImage, FNSocketLight, FNSocketMaterial,
     FNSocketMesh, FNSocketNodeTree, FNSocketText, FNSocketWorkSpace,
+    FNSocketViewLayer,
     FNSocketSceneList, FNSocketObjectList, FNSocketCollectionList, FNSocketWorldList,
     FNSocketCameraList, FNSocketImageList, FNSocketLightList, FNSocketMaterialList,
     FNSocketMeshList, FNSocketNodeTreeList, FNSocketTextList, FNSocketWorkSpaceList,
+    FNSocketViewLayerList,
 )
 
 def register():

--- a/tree.py
+++ b/tree.py
@@ -25,6 +25,7 @@ class FileNodeTreeInput(PropertyGroup):
     nodetree_value: bpy.props.PointerProperty(type=bpy.types.NodeTree, update=auto_evaluate_if_enabled)
     text_value: bpy.props.PointerProperty(type=bpy.types.Text, update=auto_evaluate_if_enabled)
     workspace_value: bpy.props.PointerProperty(type=bpy.types.WorkSpace, update=auto_evaluate_if_enabled)
+    viewlayer_value: bpy.props.PointerProperty(type=bpy.types.ViewLayer, update=auto_evaluate_if_enabled)
 
     _prop_map = {
         'FNSocketBool': 'bool_value',
@@ -44,6 +45,7 @@ class FileNodeTreeInput(PropertyGroup):
         'FNSocketNodeTree': 'nodetree_value',
         'FNSocketText': 'text_value',
         'FNSocketWorkSpace': 'workspace_value',
+        'FNSocketViewLayer': 'viewlayer_value',
     }
 
     def prop_name(self):
@@ -108,6 +110,7 @@ class FileNodesTreeInputs(PropertyGroup):
                 bpy.types.Mesh: bpy.data.meshes.remove,
                 bpy.types.Camera: bpy.data.cameras.remove,
                 bpy.types.Light: bpy.data.lights.remove,
+                bpy.types.ViewLayer: lambda vl: vl.id_data.view_layers.remove(vl),
             }
             fn = remove_map.get(type(data))
             if fn:


### PR DESCRIPTION
## Summary
- add sockets for View Layers
- map View Layer list sockets
- expose View Layer inputs in node tree properties
- clean up created View Layers during reset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68605f20272c83308d585fef19dfc6d8