### PR TITLE
Fix view layer registration

### DIFF
--- a/sockets.py
+++ b/sockets.py
@@ -177,7 +177,8 @@ class FNSocketViewLayer(NodeSocket):
         layout.label(text=text or self.name, icon='RENDERLAYERS')
     def draw_color(self, context, node):
         return _color(0.6, 0.6, 0.6)
-    value: bpy.props.PointerProperty(type=bpy.types.ViewLayer, update=auto_evaluate_if_enabled)
+    # Blender does not support PointerProperty for ViewLayer, store the name instead.
+    value: bpy.props.StringProperty(update=auto_evaluate_if_enabled)
 
 class FNSocketWorld(NodeSocket):
     bl_idname = "FNSocketWorld"

--- a/tree.py
+++ b/tree.py
@@ -25,7 +25,9 @@ class FileNodeTreeInput(PropertyGroup):
     nodetree_value: bpy.props.PointerProperty(type=bpy.types.NodeTree, update=auto_evaluate_if_enabled)
     text_value: bpy.props.PointerProperty(type=bpy.types.Text, update=auto_evaluate_if_enabled)
     workspace_value: bpy.props.PointerProperty(type=bpy.types.WorkSpace, update=auto_evaluate_if_enabled)
-    viewlayer_value: bpy.props.PointerProperty(type=bpy.types.ViewLayer, update=auto_evaluate_if_enabled)
+    # Using PointerProperty with ViewLayer is not supported in Blender 4.4,
+    # store the view layer name instead.
+    viewlayer_value: bpy.props.StringProperty(update=auto_evaluate_if_enabled)
 
     _prop_map = {
         'FNSocketBool': 'bool_value',
@@ -110,7 +112,6 @@ class FileNodesTreeInputs(PropertyGroup):
                 bpy.types.Mesh: bpy.data.meshes.remove,
                 bpy.types.Camera: bpy.data.cameras.remove,
                 bpy.types.Light: bpy.data.lights.remove,
-                bpy.types.ViewLayer: lambda vl: vl.id_data.view_layers.remove(vl),
             }
             fn = remove_map.get(type(data))
             if fn:


### PR DESCRIPTION
## Summary
- use a simple string to store view layers
- drop unused ViewLayer ID removal logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860679f9fa083309f46bc549feec74d