### PR TITLE
Fix cleanup of temporary IDs

### DIFF
--- a/tree.py
+++ b/tree.py
@@ -115,7 +115,10 @@ class FileNodesTreeInputs(PropertyGroup):
             }
             fn = remove_map.get(type(data))
             if fn:
-                fn(data)
+                try:
+                    fn(data, do_unlink=True)
+                except TypeError:
+                    fn(data)
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
- handle removal of temporary datablocks more safely
- ensure IDs are unlinked when deleted to avoid user count errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68608424a6ec83309b205967ac466a91