### PR TITLE
Fix recursive evaluation loop

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -125,7 +125,7 @@ def auto_evaluate_if_enabled(self=None, context=None):
         context = self
     context = context or bpy.context
     prefs = context.preferences.addons.get(ADDON_NAME)
-    if prefs and prefs.preferences.auto_evaluate:
+    if prefs and prefs.preferences.auto_evaluate and _active_tree is None:
         evaluate_tree(context)
 
 


### PR DESCRIPTION
## Summary
- avoid calling `evaluate_tree` during evaluation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861229852d48330bcf52df86f5c4d85