### PR TITLE
Fix view layer removal error handling

### DIFF
--- a/nodes/set_scene_viewlayers.py
+++ b/nodes/set_scene_viewlayers.py
@@ -60,7 +60,10 @@ class FNSetSceneViewlayers(Node, FNBaseNode):
 
         for vl in list(scene.view_layers)[len(filtered):]:
             if vl.name not in names:
-                scene.view_layers.remove(vl)
+                try:
+                    scene.view_layers.remove(vl)
+                except RuntimeError as err:
+                    _warn(str(err))
 
         return {"Scene": scene}
 


### PR DESCRIPTION
## Summary
- avoid raising an exception when removing view layers in `FNSetSceneViewlayers`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c09bc8c08330b6e4a5d6a18dd406