### PR TITLE
Fix group output scenes initialization

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -260,6 +260,8 @@ def _evaluate_tree(tree, context):
 
     ctx = getattr(tree, "fn_inputs", None)
     if ctx:
+        if getattr(ctx, "scenes_to_keep", None) is None:
+            ctx.scenes_to_keep = []
         for node in tree.nodes:
             if getattr(node, "bl_idname", "") == "NodeGroupOutput":
                 for sock in getattr(node, "inputs", []):


### PR DESCRIPTION
## Summary
- avoid AttributeError when evaluating nested node trees
- ensure `ctx.scenes_to_keep` exists before appending scenes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c1fa9eb08330950e4e7d460ff1d9