### PR TITLE
Fix duplicate scene creation

### DIFF
--- a/nodes/new_scene.py
+++ b/nodes/new_scene.py
@@ -26,11 +26,17 @@ class FNNewScene(Node, FNCacheIDMixin, FNBaseNode):
     def process(self, context, inputs):
         name = inputs.get("Name") or "Scene"
         cached = self.cache_get(name)
+        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
+        if cached is None and ctx:
+            storage = getattr(ctx, "_original_values", {})
+            for sc in storage.get("created_ids", []):
+                if isinstance(sc, bpy.types.Scene) and sc.name == name:
+                    cached = sc
+                    break
         if cached is not None:
             return {"Scene": cached}
         scene = bpy.data.scenes.new(name)
         self.cache_store(name, scene)
-        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
         if ctx:
             ctx.remember_created_scene(scene)
             ctx.remember_created_id(scene)


### PR DESCRIPTION
## Summary
- avoid creating a new Scene if the node already made one with the same name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c4933d188330a217299f80167da8