### PR TITLE
Fix cache for reused scenes

### DIFF
--- a/nodes/input_nodes.py
+++ b/nodes/input_nodes.py
@@ -117,6 +117,13 @@ class FNSceneInputNode(Node, FNCacheIDMixin, FNBaseNode):
         cached = self.cache_get(key)
         if cached is not None:
             return {"Scene": cached}
+        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
+        if ctx:
+            storage = getattr(ctx, "_original_values", {})
+            for sc in storage.get("created_ids", []):
+                if isinstance(sc, bpy.types.Scene) and sc.name == name:
+                    self.cache_store(key, sc)
+                    return {"Scene": sc}
         dup = scene.copy()
         dup.name = name
         self.cache_store(key, dup)

--- a/nodes/new_scene.py
+++ b/nodes/new_scene.py
@@ -25,16 +25,16 @@ class FNNewScene(Node, FNCacheIDMixin, FNBaseNode):
 
     def process(self, context, inputs):
         name = inputs.get("Name") or "Scene"
-        cached = self.cache_get(name)
         ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
-        if cached is None and ctx:
+        cached = self.cache_get(name)
+        if cached is not None:
+            return {"Scene": cached}
+        if ctx:
             storage = getattr(ctx, "_original_values", {})
             for sc in storage.get("created_ids", []):
                 if isinstance(sc, bpy.types.Scene) and sc.name == name:
-                    cached = sc
-                    break
-        if cached is not None:
-            return {"Scene": cached}
+                    self.cache_store(name, sc)
+                    return {"Scene": sc}
         scene = bpy.data.scenes.new(name)
         self.cache_store(name, scene)
         if ctx:


### PR DESCRIPTION
## Summary
- store scenes found in created_ids when reusing scenes
- mirror logic for the Scene Input node
- test that cached scenes are reused when evaluating with a group output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861cc2370508330bd380f362fcd9a4f