### PR TITLE
Reuse existing scenes during evaluation

### DIFF
--- a/nodes/input_nodes.py
+++ b/nodes/input_nodes.py
@@ -117,13 +117,25 @@ class FNSceneInputNode(Node, FNCacheIDMixin, FNBaseNode):
         cached = self.cache_get(key)
         if cached is not None:
             return {"Scene": cached}
+
         ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
         if ctx:
             storage = getattr(ctx, "_original_values", {})
             for sc in storage.get("created_ids", []):
                 if isinstance(sc, bpy.types.Scene) and sc.name == name:
-                    self.cache_store(key, sc)
-                    return {"Scene": sc}
+                    cached = sc
+                    break
+
+        if cached is None:
+            cached = bpy.data.scenes.get(name)
+
+        if cached is not None:
+            self.cache_store(key, cached)
+            if ctx:
+                ctx.remember_created_scene(cached)
+                ctx.remember_created_id(cached)
+            return {"Scene": cached}
+
         dup = scene.copy()
         dup.name = name
         self.cache_store(key, dup)

--- a/nodes/new_scene.py
+++ b/nodes/new_scene.py
@@ -29,12 +29,26 @@ class FNNewScene(Node, FNCacheIDMixin, FNBaseNode):
         cached = self.cache_get(name)
         if cached is not None:
             return {"Scene": cached}
+
         if ctx:
             storage = getattr(ctx, "_original_values", {})
             for sc in storage.get("created_ids", []):
                 if isinstance(sc, bpy.types.Scene) and sc.name == name:
-                    self.cache_store(name, sc)
-                    return {"Scene": sc}
+                    cached = sc
+                    break
+
+        if cached is None:
+            existing = bpy.data.scenes.get(name)
+            if existing is not None:
+                cached = existing
+
+        if cached is not None:
+            self.cache_store(name, cached)
+            if ctx:
+                ctx.remember_created_scene(cached)
+                ctx.remember_created_id(cached)
+            return {"Scene": cached}
+
         scene = bpy.data.scenes.new(name)
         self.cache_store(name, scene)
         if ctx:


### PR DESCRIPTION
## Summary
- reuse scenes in `FNNewScene.process` and cache them
- do the same reuse logic in `FNSceneInputNode.process`
- update fake node and tests for new behaviour
- add regression test for re-evaluating basic tree without name changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861cec5c53083308d6c363cab715e7c