### PR TITLE
Ensure scenes persist by using fake user

### DIFF
--- a/nodes/input_nodes.py
+++ b/nodes/input_nodes.py
@@ -138,6 +138,7 @@ class FNSceneInputNode(Node, FNCacheIDMixin, FNBaseNode):
 
         dup = scene.copy()
         dup.name = name
+        dup.use_fake_user = True
         self.cache_store(key, dup)
         ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
         if ctx:

--- a/nodes/new_scene.py
+++ b/nodes/new_scene.py
@@ -50,6 +50,7 @@ class FNNewScene(Node, FNCacheIDMixin, FNBaseNode):
             return {"Scene": cached}
 
         scene = bpy.data.scenes.new(name)
+        scene.use_fake_user = True
         self.cache_store(name, scene)
         if ctx:
             ctx.remember_created_scene(scene)


### PR DESCRIPTION
## Summary
- keep new scenes alive by enabling `use_fake_user`
- duplicate scenes from the Scene Input node with `use_fake_user` set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861d3f99f0c8330800751b9434f6513