### PR TITLE
Ensure unique datablocks for new nodes

### DIFF
--- a/nodes/new_collection.py
+++ b/nodes/new_collection.py
@@ -25,12 +25,31 @@ class FNNewCollection(Node, FNCacheIDMixin, FNBaseNode):
 
     def process(self, context, inputs):
         name = inputs.get("Name") or "Collection"
+        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
         cached = self.cache_get(name)
         if cached is not None:
             return {"Collection": cached}
+
+        if ctx:
+            storage = getattr(ctx, "_original_values", {})
+            for c in storage.get("created_ids", []):
+                if isinstance(c, bpy.types.Collection) and c.name == name:
+                    cached = c
+                    break
+
+        if cached is None:
+            existing = bpy.data.collections.get(name)
+            if existing is not None:
+                cached = existing
+
+        if cached is not None:
+            self.cache_store(name, cached)
+            if ctx:
+                ctx.remember_created_id(cached)
+            return {"Collection": cached}
+
         coll = bpy.data.collections.new(name)
         self.cache_store(name, coll)
-        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
         if ctx:
             ctx.remember_created_id(coll)
         return {"Collection": coll}

--- a/nodes/new_viewlayer.py
+++ b/nodes/new_viewlayer.py
@@ -30,12 +30,31 @@ class FNNewViewLayer(Node, FNCacheIDMixin, FNBaseNode):
             return {"ViewLayer": None}
         name = inputs.get("Name") or "ViewLayer"
         key = (scene.as_pointer(), name)
+        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
         cached = self.cache_get(key)
         if cached is not None:
             return {"ViewLayer": cached}
+
+        if ctx:
+            storage = getattr(ctx, "_original_values", {})
+            for vl in storage.get("created_ids", []):
+                if getattr(vl, "name", None) == name and getattr(vl, "id_data", None) is scene:
+                    cached = vl
+                    break
+
+        if cached is None and hasattr(scene, "view_layers"):
+            existing = scene.view_layers.get(name) if hasattr(scene.view_layers, "get") else None
+            if existing is not None:
+                cached = existing
+
+        if cached is not None:
+            self.cache_store(key, cached)
+            if ctx:
+                ctx.remember_created_id(cached)
+            return {"ViewLayer": cached}
+
         view_layer = scene.view_layers.new(name)
         self.cache_store(key, view_layer)
-        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
         if ctx:
             ctx.remember_created_id(view_layer)
         return {"ViewLayer": view_layer}

--- a/nodes/new_world.py
+++ b/nodes/new_world.py
@@ -25,12 +25,31 @@ class FNNewWorld(Node, FNCacheIDMixin, FNBaseNode):
 
     def process(self, context, inputs):
         name = inputs.get("Name") or "World"
+        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
         cached = self.cache_get(name)
         if cached is not None:
             return {"World": cached}
+
+        if ctx:
+            storage = getattr(ctx, "_original_values", {})
+            for w in storage.get("created_ids", []):
+                if isinstance(w, bpy.types.World) and w.name == name:
+                    cached = w
+                    break
+
+        if cached is None:
+            existing = bpy.data.worlds.get(name)
+            if existing is not None:
+                cached = existing
+
+        if cached is not None:
+            self.cache_store(name, cached)
+            if ctx:
+                ctx.remember_created_id(cached)
+            return {"World": cached}
+
         world = bpy.data.worlds.new(name)
         self.cache_store(name, world)
-        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
         if ctx:
             ctx.remember_created_id(world)
         return {"World": world}


### PR DESCRIPTION
## Summary
- prevent duplicate datablocks in `New Collection`, `New Material`, `New World`, `New Object`, and `New ViewLayer` nodes
- add regression tests for reusing existing collections, materials and worlds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861d81f9c388330b26983ed9df3c764