### PR TITLE
Ensure unique datablocks

### DIFF
--- a/nodes/new_object.py
+++ b/nodes/new_object.py
@@ -57,31 +57,46 @@ class FNNewObject(Node, FNCacheIDMixin, FNBaseNode):
         self._invalidate_cache()
 
     def process(self, context, inputs):
-        data = None
+        data = inputs.get("Data")
         created_data = None
-        if self.obj_type == 'MESH':
-            data = inputs.get("Data")
-            if not data:
-                data = bpy.data.meshes.new(f"{inputs.get('Name') or 'Object'}Mesh")
-                created_data = data
-        elif self.obj_type == 'LIGHT':
-            data = inputs.get("Data")
-            if not data:
-                data = bpy.data.lights.new(f"{inputs.get('Name') or 'Object'}Light", type='POINT')
-                created_data = data
-        elif self.obj_type == 'CAMERA':
-            data = inputs.get("Data")
-            if not data:
-                data = bpy.data.cameras.new(f"{inputs.get('Name') or 'Object'}Camera")
-                created_data = data
         name = inputs.get("Name") or "Object"
         key = (self.obj_type, name, data)
         cached = self.cache_get(key)
+        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
         if cached is not None:
             return {"Object": cached}
+
+        if ctx:
+            storage = getattr(ctx, "_original_values", {})
+            for obj in storage.get("created_ids", []):
+                if isinstance(obj, bpy.types.Object) and obj.name == name:
+                    cached = obj
+                    break
+
+        if cached is None:
+            existing = bpy.data.objects.get(name)
+            if existing is not None:
+                cached = existing
+
+        if cached is not None:
+            self.cache_store(key, cached)
+            if ctx:
+                ctx.remember_created_id(cached)
+            return {"Object": cached}
+
+        if data is None:
+            if self.obj_type == 'MESH':
+                data = bpy.data.meshes.new(f"{name}Mesh")
+                created_data = data
+            elif self.obj_type == 'LIGHT':
+                data = bpy.data.lights.new(f"{name}Light", type='POINT')
+                created_data = data
+            elif self.obj_type == 'CAMERA':
+                data = bpy.data.cameras.new(f"{name}Camera")
+                created_data = data
+
         obj = bpy.data.objects.new(name, data)
         self.cache_store(key, obj)
-        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
         if ctx:
             ctx.remember_created_id(obj)
             if created_data:

--- a/nodes/new_viewlayer.py
+++ b/nodes/new_viewlayer.py
@@ -31,11 +31,30 @@ class FNNewViewLayer(Node, FNCacheIDMixin, FNBaseNode):
         name = inputs.get("Name") or "ViewLayer"
         key = (scene.as_pointer(), name)
         cached = self.cache_get(key)
+        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
         if cached is not None:
             return {"ViewLayer": cached}
+
+        if ctx:
+            storage = getattr(ctx, "_original_values", {})
+            for vl in storage.get("created_ids", []):
+                if isinstance(vl, bpy.types.ViewLayer) and vl.name == name and vl.id_data == scene:
+                    cached = vl
+                    break
+
+        if cached is None:
+            existing = scene.view_layers.get(name)
+            if existing is not None:
+                cached = existing
+
+        if cached is not None:
+            self.cache_store(key, cached)
+            if ctx:
+                ctx.remember_created_id(cached)
+            return {"ViewLayer": cached}
+
         view_layer = scene.view_layers.new(name)
         self.cache_store(key, view_layer)
-        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
         if ctx:
             ctx.remember_created_id(view_layer)
         return {"ViewLayer": view_layer}

--- a/nodes/new_world.py
+++ b/nodes/new_world.py
@@ -26,11 +26,30 @@ class FNNewWorld(Node, FNCacheIDMixin, FNBaseNode):
     def process(self, context, inputs):
         name = inputs.get("Name") or "World"
         cached = self.cache_get(name)
+        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
         if cached is not None:
             return {"World": cached}
+
+        if ctx:
+            storage = getattr(ctx, "_original_values", {})
+            for world in storage.get("created_ids", []):
+                if isinstance(world, bpy.types.World) and world.name == name:
+                    cached = world
+                    break
+
+        if cached is None:
+            existing = bpy.data.worlds.get(name)
+            if existing is not None:
+                cached = existing
+
+        if cached is not None:
+            self.cache_store(name, cached)
+            if ctx:
+                ctx.remember_created_id(cached)
+            return {"World": cached}
+
         world = bpy.data.worlds.new(name)
         self.cache_store(name, world)
-        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
         if ctx:
             ctx.remember_created_id(world)
         return {"World": world}


### PR DESCRIPTION
## Summary
- avoid duplicates in new datablock nodes
- check for existing data before creating collections, materials, objects, view layers and worlds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861d81f9c388330b26983ed9df3c764