### PR TITLE
Fix duplication for datablock creation nodes

### DIFF
--- a/nodes/new_material.py
+++ b/nodes/new_material.py
@@ -28,9 +28,28 @@ class FNNewMaterial(Node, FNCacheIDMixin, FNBaseNode):
         cached = self.cache_get(name)
         if cached is not None:
             return {"Material": cached}
+
+        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
+        if ctx:
+            storage = getattr(ctx, "_original_values", {})
+            for m in storage.get("created_ids", []):
+                if isinstance(m, bpy.types.Material) and m.name == name:
+                    cached = m
+                    break
+
+        if cached is None:
+            existing = bpy.data.materials.get(name)
+            if existing is not None:
+                cached = existing
+
+        if cached is not None:
+            self.cache_store(name, cached)
+            if ctx:
+                ctx.remember_created_id(cached)
+            return {"Material": cached}
+
         mat = bpy.data.materials.new(name)
         self.cache_store(name, mat)
-        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
         if ctx:
             ctx.remember_created_id(mat)
         return {"Material": mat}

--- a/nodes/new_world.py
+++ b/nodes/new_world.py
@@ -28,9 +28,28 @@ class FNNewWorld(Node, FNCacheIDMixin, FNBaseNode):
         cached = self.cache_get(name)
         if cached is not None:
             return {"World": cached}
+
+        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
+        if ctx:
+            storage = getattr(ctx, "_original_values", {})
+            for w in storage.get("created_ids", []):
+                if isinstance(w, bpy.types.World) and w.name == name:
+                    cached = w
+                    break
+
+        if cached is None:
+            existing = bpy.data.worlds.get(name)
+            if existing is not None:
+                cached = existing
+
+        if cached is not None:
+            self.cache_store(name, cached)
+            if ctx:
+                ctx.remember_created_id(cached)
+            return {"World": cached}
+
         world = bpy.data.worlds.new(name)
         self.cache_store(name, world)
-        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
         if ctx:
             ctx.remember_created_id(world)
         return {"World": world}


### PR DESCRIPTION
## Summary
- avoid creating duplicate datablocks in *New* nodes
- reuse existing world, collection, material, object or viewlayer when names match

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861d81f9c388330b26983ed9df3c764