### PR TITLE
Add nodes for creating new datablocks

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -72,14 +72,17 @@ categories = [
     ]),
     NodeCategory('FILE_NODES_CAMERA', 'Camera', items=[
         NodeItem('FNCameraInputNode'),
+        NodeItem('FNNewCamera'),
         NodeItem('FNCameraProps'),
     ]),
     NodeCategory('FILE_NODES_LIGHT', 'Light', items=[
         NodeItem('FNLightInputNode'),
+        NodeItem('FNNewLight'),
         NodeItem('FNLightProps'),
     ]),
     NodeCategory('FILE_NODES_MESH', 'Mesh', items=[
         NodeItem('FNMeshInputNode'),
+        NodeItem('FNNewMesh'),
         NodeItem('FNMeshProps'),
     ]),
     NodeCategory('FILE_NODES_IMAGE', 'Image', items=[
@@ -90,6 +93,7 @@ categories = [
     ]),
     NodeCategory('FILE_NODES_TEXT', 'Text', items=[
         NodeItem('FNTextInputNode'),
+        NodeItem('FNNewText'),
     ]),
     NodeCategory('FILE_NODES_WORKSPACE', 'WorkSpace', items=[
         NodeItem('FNWorkSpaceInputNode'),

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -14,6 +14,7 @@ from . import (
     cycles_object_props, eevee_object_props, collection_props,
     world_props, camera_props, light_props, mesh_props, material_props,
     new_scene, new_object, new_collection, new_world, new_material, new_viewlayer,
+    new_camera, new_light, new_mesh, new_text,
     set_scene_name, set_collection_name, set_object_name,
     viewlayer_visibility, scene_viewlayers,set_scene_viewlayers,
     switch, index_switch, outliner
@@ -29,6 +30,7 @@ _modules = [
     cycles_object_props, eevee_object_props, collection_props,
     world_props, camera_props, light_props, mesh_props, material_props,
     new_scene, new_object, new_collection, new_world, new_material, new_viewlayer,
+    new_camera, new_light, new_mesh, new_text,
     set_scene_name, set_collection_name, set_object_name,
     viewlayer_visibility, scene_viewlayers,set_scene_viewlayers,
     switch, index_switch, outliner

--- a/nodes/new_camera.py
+++ b/nodes/new_camera.py
@@ -1,0 +1,63 @@
+"""Node for creating new cameras."""
+
+import bpy
+from bpy.types import Node
+from .base import FNBaseNode, FNCacheIDMixin
+from ..sockets import FNSocketCamera, FNSocketString
+
+
+class FNNewCamera(Node, FNCacheIDMixin, FNBaseNode):
+    """Create a new camera datablock."""
+    bl_idname = "FNNewCamera"
+    bl_label = "New Camera"
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        sock = self.inputs.new('FNSocketString', "Name")
+        sock.value = "Camera"
+        self.outputs.new('FNSocketCamera', "Camera")
+
+    def free(self):
+        self._invalidate_cache()
+
+    def process(self, context, inputs):
+        name = inputs.get("Name") or "Camera"
+        cached = self.cache_get(name)
+        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
+        if cached is not None:
+            return {"Camera": cached}
+
+        if ctx:
+            storage = getattr(ctx, "_original_values", {})
+            for cam in storage.get("created_ids", []):
+                if isinstance(cam, bpy.types.Camera) and cam.name == name:
+                    cached = cam
+                    break
+
+        if cached is None:
+            existing = bpy.data.cameras.get(name)
+            if existing is not None:
+                cached = existing
+
+        if cached is not None:
+            self.cache_store(name, cached)
+            if ctx:
+                ctx.remember_created_id(cached)
+            return {"Camera": cached}
+
+        cam = bpy.data.cameras.new(name)
+        self.cache_store(name, cam)
+        if ctx:
+            ctx.remember_created_id(cam)
+        return {"Camera": cam}
+
+
+def register():
+    bpy.utils.register_class(FNNewCamera)
+
+
+def unregister():
+    bpy.utils.unregister_class(FNNewCamera)

--- a/nodes/new_light.py
+++ b/nodes/new_light.py
@@ -1,0 +1,79 @@
+"""Node for creating new lights."""
+
+import bpy
+from bpy.types import Node
+from .base import FNBaseNode, FNCacheIDMixin
+from ..sockets import FNSocketLight, FNSocketString
+
+
+class FNNewLight(Node, FNCacheIDMixin, FNBaseNode):
+    """Create a new light datablock."""
+    bl_idname = "FNNewLight"
+    bl_label = "New Light"
+
+    light_type: bpy.props.EnumProperty(
+        name="Type",
+        items=[
+            ('POINT', 'Point', ''),
+            ('SUN', 'Sun', ''),
+            ('SPOT', 'Spot', ''),
+            ('AREA', 'Area', ''),
+        ],
+        default='POINT',
+        update=lambda self, context: None,
+    )
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        sock = self.inputs.new('FNSocketString', "Name")
+        sock.value = "Light"
+        self.outputs.new('FNSocketLight', "Light")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "light_type", text="Type")
+
+    def free(self):
+        self._invalidate_cache()
+
+    def process(self, context, inputs):
+        name = inputs.get("Name") or "Light"
+        key = (name, self.light_type)
+        cached = self.cache_get(key)
+        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
+        if cached is not None:
+            return {"Light": cached}
+
+        if ctx:
+            storage = getattr(ctx, "_original_values", {})
+            for lt in storage.get("created_ids", []):
+                if isinstance(lt, bpy.types.Light) and lt.name == name:
+                    cached = lt
+                    break
+
+        if cached is None:
+            existing = bpy.data.lights.get(name)
+            if existing is not None:
+                cached = existing
+
+        if cached is not None:
+            self.cache_store(key, cached)
+            if ctx:
+                ctx.remember_created_id(cached)
+            return {"Light": cached}
+
+        light = bpy.data.lights.new(name, type=self.light_type)
+        self.cache_store(key, light)
+        if ctx:
+            ctx.remember_created_id(light)
+        return {"Light": light}
+
+
+def register():
+    bpy.utils.register_class(FNNewLight)
+
+
+def unregister():
+    bpy.utils.unregister_class(FNNewLight)

--- a/nodes/new_mesh.py
+++ b/nodes/new_mesh.py
@@ -1,0 +1,63 @@
+"""Node for creating new meshes."""
+
+import bpy
+from bpy.types import Node
+from .base import FNBaseNode, FNCacheIDMixin
+from ..sockets import FNSocketMesh, FNSocketString
+
+
+class FNNewMesh(Node, FNCacheIDMixin, FNBaseNode):
+    """Create a new mesh datablock."""
+    bl_idname = "FNNewMesh"
+    bl_label = "New Mesh"
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        sock = self.inputs.new('FNSocketString', "Name")
+        sock.value = "Mesh"
+        self.outputs.new('FNSocketMesh', "Mesh")
+
+    def free(self):
+        self._invalidate_cache()
+
+    def process(self, context, inputs):
+        name = inputs.get("Name") or "Mesh"
+        cached = self.cache_get(name)
+        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
+        if cached is not None:
+            return {"Mesh": cached}
+
+        if ctx:
+            storage = getattr(ctx, "_original_values", {})
+            for me in storage.get("created_ids", []):
+                if isinstance(me, bpy.types.Mesh) and me.name == name:
+                    cached = me
+                    break
+
+        if cached is None:
+            existing = bpy.data.meshes.get(name)
+            if existing is not None:
+                cached = existing
+
+        if cached is not None:
+            self.cache_store(name, cached)
+            if ctx:
+                ctx.remember_created_id(cached)
+            return {"Mesh": cached}
+
+        mesh = bpy.data.meshes.new(name)
+        self.cache_store(name, mesh)
+        if ctx:
+            ctx.remember_created_id(mesh)
+        return {"Mesh": mesh}
+
+
+def register():
+    bpy.utils.register_class(FNNewMesh)
+
+
+def unregister():
+    bpy.utils.unregister_class(FNNewMesh)

--- a/nodes/new_text.py
+++ b/nodes/new_text.py
@@ -1,0 +1,63 @@
+"""Node for creating new text datablocks."""
+
+import bpy
+from bpy.types import Node
+from .base import FNBaseNode, FNCacheIDMixin
+from ..sockets import FNSocketText, FNSocketString
+
+
+class FNNewText(Node, FNCacheIDMixin, FNBaseNode):
+    """Create a new text datablock."""
+    bl_idname = "FNNewText"
+    bl_label = "New Text"
+
+    @classmethod
+    def poll(cls, ntree):
+        return ntree.bl_idname == "FileNodesTreeType"
+
+    def init(self, context):
+        sock = self.inputs.new('FNSocketString', "Name")
+        sock.value = "Text"
+        self.outputs.new('FNSocketText', "Text")
+
+    def free(self):
+        self._invalidate_cache()
+
+    def process(self, context, inputs):
+        name = inputs.get("Name") or "Text"
+        cached = self.cache_get(name)
+        ctx = getattr(getattr(self, "id_data", None), "fn_inputs", None)
+        if cached is not None:
+            return {"Text": cached}
+
+        if ctx:
+            storage = getattr(ctx, "_original_values", {})
+            for txt in storage.get("created_ids", []):
+                if isinstance(txt, bpy.types.Text) and txt.name == name:
+                    cached = txt
+                    break
+
+        if cached is None:
+            existing = bpy.data.texts.get(name)
+            if existing is not None:
+                cached = existing
+
+        if cached is not None:
+            self.cache_store(name, cached)
+            if ctx:
+                ctx.remember_created_id(cached)
+            return {"Text": cached}
+
+        text = bpy.data.texts.new(name)
+        self.cache_store(name, text)
+        if ctx:
+            ctx.remember_created_id(text)
+        return {"Text": text}
+
+
+def register():
+    bpy.utils.register_class(FNNewText)
+
+
+def unregister():
+    bpy.utils.unregister_class(FNNewText)

--- a/tree.py
+++ b/tree.py
@@ -112,6 +112,7 @@ class FileNodesTreeInputs(PropertyGroup):
                 bpy.types.Mesh: bpy.data.meshes.remove,
                 bpy.types.Camera: bpy.data.cameras.remove,
                 bpy.types.Light: bpy.data.lights.remove,
+                bpy.types.Text: bpy.data.texts.remove,
             }
             fn = remove_map.get(type(data))
             if fn:


### PR DESCRIPTION
## Summary
- implement nodes for creating camera, light, mesh and text datablocks
- expose these nodes in the UI menus
- import the new node modules
- remove Text datablocks when cleaning up evaluation

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e27f8ea8833085c968221e241f84