### PR TITLE
Add execution sockets and logic node

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ File Nodes es un prototipo de addon para Blender que extiende el paradigma proce
 ## Objetivos del MVP
 - Crear un nuevo `NodeTree` personalizado.
 - Implementar nodos básicos para leer y manipular datablocks.
+- Incorporar sockets de ejecución para exponer acciones como "Render Scenes" en los grupos.
 
 ## Arquitectura general
 1. **NodeTree personalizado**: contenedor del grafo.

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -17,7 +17,7 @@ from . import (
     new_camera, new_light, new_mesh, new_text,
     set_scene_name, set_collection_name, set_object_name,
     viewlayer_visibility, scene_viewlayers,set_scene_viewlayers,
-    switch, index_switch, outliner
+    switch, index_switch, outliner, logic_exec
 )
 
 _modules = [
@@ -33,7 +33,7 @@ _modules = [
     new_camera, new_light, new_mesh, new_text,
     set_scene_name, set_collection_name, set_object_name,
     viewlayer_visibility, scene_viewlayers,set_scene_viewlayers,
-    switch, index_switch, outliner
+    switch, index_switch, outliner, logic_exec
 ]
 
 def register():

--- a/nodes/logic_exec.py
+++ b/nodes/logic_exec.py
@@ -1,0 +1,42 @@
+import bpy
+from bpy.types import Node
+from .base import FNBaseNode
+from ..operators import auto_evaluate_if_enabled
+from ..sockets import FNSocketExec
+
+class FNLogicExec(Node, FNBaseNode):
+    """Logic operations for execution sockets."""
+    bl_idname = "FNLogicExec"
+    bl_label = "Logic"
+
+    operation: bpy.props.EnumProperty(
+        name="Operation",
+        items=[('AND', 'And', ''), ('OR', 'Or', '')],
+        default='OR',
+        update=lambda self, context: auto_evaluate_if_enabled(context)
+    )
+
+    def init(self, context):
+        self.inputs.new('FNSocketExec', "A")
+        self.inputs.new('FNSocketExec', "B")
+        self.outputs.new('FNSocketExec', "Result")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "operation", text="")
+
+    def process(self, context, inputs):
+        a = bool(inputs.get("A"))
+        b = bool(inputs.get("B"))
+        if self.operation == 'AND':
+            value = a and b
+        else:
+            value = a or b
+        return {"Result": value}
+
+
+def register():
+    bpy.utils.register_class(FNLogicExec)
+
+
+def unregister():
+    bpy.utils.unregister_class(FNLogicExec)

--- a/nodes/output_nodes.py
+++ b/nodes/output_nodes.py
@@ -4,7 +4,7 @@ import bpy
 from bpy.types import Node
 
 from .base import FNBaseNode
-from ..sockets import FNSocketSceneList
+from ..sockets import FNSocketSceneList, FNSocketExec
 
 
 
@@ -18,6 +18,8 @@ class FNRenderScenesNode(Node, FNBaseNode):
         return ntree.bl_idname == "FileNodesTreeType"
 
     def init(self, context):
+        exec_sock = self.inputs.new('FNSocketExec', "Execute")
+        exec_sock.operator = 'file_nodes.render_scenes'
         sock = self.inputs.new('FNSocketSceneList', "Scenes")
         sock.display_shape = 'SQUARE'
 

--- a/sockets.py
+++ b/sockets.py
@@ -25,6 +25,26 @@ class FNSocketBool(NodeSocket):
         return _color(1.0, 0.4118, 0.8627)
     value: bpy.props.BoolProperty(update=auto_evaluate_if_enabled)
 
+# Execution socket used to trigger operators. When unlinked and configured
+# with an operator idname, it draws a button so the action can be exposed in
+# group inputs.
+class FNSocketExec(NodeSocket):
+    bl_idname = "FNSocketExec"
+    bl_label = "Execution"
+
+    operator: bpy.props.StringProperty(name="Operator", default="")
+    show_selector: bpy.props.BoolProperty(default=True)
+
+    def draw(self, context, layout, node, text):
+        if self.is_output and not self.is_linked and self.operator and self.show_selector:
+            layout.operator(self.operator, text=text or self.name, icon='PLAY')
+        else:
+            layout.label(text=text or self.name)
+
+    def draw_color(self, context, node):
+        return _color(1.0, 0.5, 0.0)
+    value: bpy.props.BoolProperty(update=auto_evaluate_if_enabled)
+
 class FNSocketFloat(NodeSocket):
     bl_idname = "FNSocketFloat"
     bl_label = "Float"
@@ -321,7 +341,8 @@ class FNSocketViewLayerList(NodeSocket):
         return _color(0.6, 0.6, 0.6)
 
 _all_sockets = (
-    FNSocketBool, FNSocketFloat, FNSocketVector, FNSocketInt,
+    FNSocketBool, FNSocketExec,
+    FNSocketFloat, FNSocketVector, FNSocketInt,
     FNSocketString, FNSocketStringList,
     FNSocketScene, FNSocketObject, FNSocketCollection, FNSocketWorld,
     FNSocketCamera, FNSocketImage, FNSocketLight, FNSocketMaterial,

--- a/tree.py
+++ b/tree.py
@@ -8,6 +8,7 @@ class FileNodeTreeInput(PropertyGroup):
     socket_type: bpy.props.StringProperty()
 
     bool_value: bpy.props.BoolProperty(update=auto_evaluate_if_enabled)
+    exec_value: bpy.props.BoolProperty(update=auto_evaluate_if_enabled)
     int_value: bpy.props.IntProperty(update=auto_evaluate_if_enabled)
     float_value: bpy.props.FloatProperty(update=auto_evaluate_if_enabled)
     vector_value: bpy.props.FloatVectorProperty(size=3, update=auto_evaluate_if_enabled)
@@ -31,6 +32,7 @@ class FileNodeTreeInput(PropertyGroup):
 
     _prop_map = {
         'FNSocketBool': 'bool_value',
+        'FNSocketExec': 'exec_value',
         'FNSocketInt': 'int_value',
         'FNSocketFloat': 'float_value',
         'FNSocketVector': 'vector_value',


### PR DESCRIPTION
## Summary
- add `FNSocketExec` to expose operator buttons via sockets
- allow trees to store execution values
- add execution input on `Render Scenes` node
- implement `FNLogicExec` node for basic AND/OR logic
- document new execution sockets in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862346d35ac833096f6aaf97e4b035a