### PR TITLE
Add execution sockets and logic node

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ File Nodes es un prototipo de addon para Blender que extiende el paradigma proce
 ## Arquitectura general
 1. **NodeTree personalizado**: contenedor del grafo.
 2. **Nodos**: clases que heredan de `bpy.types.Node`.
-3. **Sockets**: tipos propios para listas de objetos, escenas, etc.
+3. **Sockets**: tipos propios para listas de objetos, escenas y ahora un socket de
+   *ejecución* para exponer acciones como "Render Scenes" a través del `Group Input`.
 4. **Árboles globales**: los `FileNodesTree` residen en `bpy.data.node_groups` y se evalúan de forma conjunta.
 
 ## Modelo de ejecución

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -17,7 +17,7 @@ from . import (
     new_camera, new_light, new_mesh, new_text,
     set_scene_name, set_collection_name, set_object_name,
     viewlayer_visibility, scene_viewlayers,set_scene_viewlayers,
-    switch, index_switch, outliner
+    switch, index_switch, outliner, exec_logic
 )
 
 _modules = [
@@ -33,7 +33,7 @@ _modules = [
     new_camera, new_light, new_mesh, new_text,
     set_scene_name, set_collection_name, set_object_name,
     viewlayer_visibility, scene_viewlayers,set_scene_viewlayers,
-    switch, index_switch, outliner
+    switch, index_switch, outliner, exec_logic
 ]
 
 def register():

--- a/nodes/exec_logic.py
+++ b/nodes/exec_logic.py
@@ -1,0 +1,59 @@
+import bpy
+from bpy.types import Node
+
+from .base import FNBaseNode
+from ..operators import auto_evaluate_if_enabled
+from ..sockets import FNSocketExec
+
+
+class FNExecLogic(Node, FNBaseNode):
+    """Logic operations on execution sockets."""
+    bl_idname = "FNExecLogic"
+    bl_label = "Execution Logic"
+
+    op: bpy.props.EnumProperty(
+        name="Operation",
+        items=[('AND', 'And', ''), ('OR', 'Or', '')],
+        default='AND',
+        update=auto_evaluate_if_enabled,
+    )
+
+    input_count: bpy.props.IntProperty(
+        name="Inputs",
+        default=2,
+        min=1,
+        update=lambda self, ctx: self._update_sockets(ctx)
+    )
+
+    def _update_sockets(self, context=None):
+        while self.inputs:
+            self.inputs.remove(self.inputs[-1])
+        while self.outputs:
+            self.outputs.remove(self.outputs[-1])
+        count = max(1, int(self.input_count))
+        for i in range(count):
+            self.inputs.new('FNSocketExec', f"Exec {i}")
+        self.outputs.new('FNSocketExec', 'Exec')
+        if context is not None:
+            auto_evaluate_if_enabled(context)
+
+    def init(self, context):
+        self._update_sockets(context)
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "op", text="Operation")
+        layout.prop(self, "input_count", text="Inputs")
+
+    def process(self, context, inputs):
+        values = [inputs.get(f"Exec {i}") for i in range(max(1, int(self.input_count)))]
+        values = [bool(v) for v in values]
+        result = all(values) if self.op == 'AND' else any(values)
+        return {"Exec": result}
+
+
+def register():
+    bpy.utils.register_class(FNExecLogic)
+
+
+def unregister():
+    bpy.utils.unregister_class(FNExecLogic)

--- a/nodes/output_nodes.py
+++ b/nodes/output_nodes.py
@@ -4,7 +4,7 @@ import bpy
 from bpy.types import Node
 
 from .base import FNBaseNode
-from ..sockets import FNSocketSceneList
+from ..sockets import FNSocketSceneList, FNSocketExec
 
 
 
@@ -18,6 +18,7 @@ class FNRenderScenesNode(Node, FNBaseNode):
         return ntree.bl_idname == "FileNodesTreeType"
 
     def init(self, context):
+        self.inputs.new('FNSocketExec', "Exec")
         sock = self.inputs.new('FNSocketSceneList', "Scenes")
         sock.display_shape = 'SQUARE'
 
@@ -25,7 +26,15 @@ class FNRenderScenesNode(Node, FNBaseNode):
         layout.operator('file_nodes.render_scenes', text="Render Scenes")
 
     def process(self, context, inputs):
-        # Terminal node, no automatic action
+        if inputs.get("Exec"):
+            scenes = inputs.get("Scenes") or []
+            for sc in scenes:
+                if not sc:
+                    continue
+                try:
+                    bpy.ops.render.render("INVOKE_DEFAULT", scene=sc.name)
+                except Exception:
+                    pass
         return {}
 
 

--- a/sockets.py
+++ b/sockets.py
@@ -25,6 +25,15 @@ class FNSocketBool(NodeSocket):
         return _color(1.0, 0.4118, 0.8627)
     value: bpy.props.BoolProperty(update=auto_evaluate_if_enabled)
 
+class FNSocketExec(NodeSocket):
+    bl_idname = "FNSocketExec"
+    bl_label = "Execution"
+    def draw(self, context, layout, node, text):
+        _draw_value_socket(self, layout, text, 'PLAY')
+    def draw_color(self, context, node):
+        return _color(1.0, 0.5, 0.0)
+    value: bpy.props.BoolProperty(update=auto_evaluate_if_enabled)
+
 class FNSocketFloat(NodeSocket):
     bl_idname = "FNSocketFloat"
     bl_label = "Float"
@@ -321,7 +330,7 @@ class FNSocketViewLayerList(NodeSocket):
         return _color(0.6, 0.6, 0.6)
 
 _all_sockets = (
-    FNSocketBool, FNSocketFloat, FNSocketVector, FNSocketInt,
+    FNSocketBool, FNSocketExec, FNSocketFloat, FNSocketVector, FNSocketInt,
     FNSocketString, FNSocketStringList,
     FNSocketScene, FNSocketObject, FNSocketCollection, FNSocketWorld,
     FNSocketCamera, FNSocketImage, FNSocketLight, FNSocketMaterial,

--- a/tree.py
+++ b/tree.py
@@ -8,6 +8,7 @@ class FileNodeTreeInput(PropertyGroup):
     socket_type: bpy.props.StringProperty()
 
     bool_value: bpy.props.BoolProperty(update=auto_evaluate_if_enabled)
+    exec_value: bpy.props.BoolProperty(update=auto_evaluate_if_enabled)
     int_value: bpy.props.IntProperty(update=auto_evaluate_if_enabled)
     float_value: bpy.props.FloatProperty(update=auto_evaluate_if_enabled)
     vector_value: bpy.props.FloatVectorProperty(size=3, update=auto_evaluate_if_enabled)
@@ -31,6 +32,7 @@ class FileNodeTreeInput(PropertyGroup):
 
     _prop_map = {
         'FNSocketBool': 'bool_value',
+        'FNSocketExec': 'exec_value',
         'FNSocketInt': 'int_value',
         'FNSocketFloat': 'float_value',
         'FNSocketVector': 'vector_value',


### PR DESCRIPTION
## Summary
- add `FNSocketExec` to represent trigger sockets
- store execution values on tree inputs
- integrate `FNSocketExec` into node registration
- add `FNExecLogic` node for AND/OR of execution signals
- expose execution input on Render Scenes node
- document new socket type

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862346d35ac833096f6aaf97e4b035a