### PR TITLE
Add trigger operator for execution sockets

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -67,6 +67,39 @@ class FN_OT_ungroup_nodes(Operator):
         return {"FINISHED"}
 
 
+class FN_OT_trigger_exec(Operator):
+    bl_idname = "file_nodes.trigger_exec"
+    bl_label = "Execute Socket"
+
+    tree_name: bpy.props.StringProperty()
+    node_name: bpy.props.StringProperty()
+    socket_name: bpy.props.StringProperty()
+    group_input: bpy.props.BoolProperty(default=False)
+
+    def execute(self, context):
+        tree = bpy.data.node_groups.get(self.tree_name)
+        if not tree:
+            return {'CANCELLED'}
+        if self.group_input:
+            inp = tree.fn_inputs.inputs.get(self.socket_name)
+            if not inp:
+                return {'CANCELLED'}
+            inp.exec_value = True
+            auto_evaluate_if_enabled(context=context)
+            inp.exec_value = False
+        else:
+            node = tree.nodes.get(self.node_name)
+            if not node:
+                return {'CANCELLED'}
+            sock = node.inputs.get(self.socket_name)
+            if not sock:
+                return {'CANCELLED'}
+            sock.value = True
+            auto_evaluate_if_enabled(context=context)
+            sock.value = False
+        return {'FINISHED'}
+
+
 class FN_OT_render_scenes(Operator):
     bl_idname = "file_nodes.render_scenes"
     bl_label = "Render Scenes"
@@ -283,6 +316,7 @@ def register():
     bpy.utils.register_class(FN_OT_evaluate_all)
     bpy.utils.register_class(FN_OT_group_nodes)
     bpy.utils.register_class(FN_OT_ungroup_nodes)
+    bpy.utils.register_class(FN_OT_trigger_exec)
     bpy.utils.register_class(FN_OT_render_scenes)
     bpy.utils.register_class(FN_OT_new_tree)
     bpy.utils.register_class(FN_OT_remove_tree)
@@ -292,6 +326,7 @@ def unregister():
     bpy.utils.unregister_class(FN_OT_remove_tree)
     bpy.utils.unregister_class(FN_OT_new_tree)
     bpy.utils.unregister_class(FN_OT_render_scenes)
+    bpy.utils.unregister_class(FN_OT_trigger_exec)
     bpy.utils.unregister_class(FN_OT_ungroup_nodes)
     bpy.utils.unregister_class(FN_OT_group_nodes)
     bpy.utils.unregister_class(FN_OT_evaluate_all)

--- a/sockets.py
+++ b/sockets.py
@@ -29,7 +29,14 @@ class FNSocketExec(NodeSocket):
     bl_idname = "FNSocketExec"
     bl_label = "Execution"
     def draw(self, context, layout, node, text):
-        _draw_value_socket(self, layout, text, 'PLAY')
+        if self.is_output:
+            layout.label(text=text or self.name, icon='PLAY')
+        else:
+            op = layout.operator('file_nodes.trigger_exec', text=text or self.name, icon='PLAY')
+            op.tree_name = node.id_data.name
+            op.node_name = node.name
+            op.socket_name = self.name
+            op.group_input = False
     def draw_color(self, context, node):
         return _color(1.0, 0.5, 0.0)
     value: bpy.props.BoolProperty(update=auto_evaluate_if_enabled)

--- a/ui.py
+++ b/ui.py
@@ -35,7 +35,13 @@ class FILE_NODES_PT_global(Panel):
                     if inp:
                         prop = inp.prop_name()
                         if prop:
-                            box.prop(inp, prop, text=item.name)
+                            if item.socket_type == 'FNSocketExec':
+                                op = box.operator('file_nodes.trigger_exec', text=item.name, icon='PLAY')
+                                op.tree_name = tree.name
+                                op.socket_name = item.name
+                                op.group_input = True
+                            else:
+                                box.prop(inp, prop, text=item.name)
 
 
 def _tree_prop_update(self, context):


### PR DESCRIPTION
## Summary
- turn execution socket into a clickable button
- add operator to toggle socket values and run evaluation
- show execution inputs as buttons in the UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686239fa2ab48330b1b79829e5aa5e1e