### PR TITLE
Enforce COW updates on nodes

### DIFF
--- a/nodes/camera_props.py
+++ b/nodes/camera_props.py
@@ -29,7 +29,7 @@ class FNCameraProps(Node, FNBaseNode):
         cam = inputs.get("Camera")
         if cam:
             lens = inputs.get("Focal Length")
-            ensure_mutable(cam)
+            cam = ensure_mutable(cam)
             try:
                 cam.lens = lens
             except Exception:

--- a/nodes/collection_props.py
+++ b/nodes/collection_props.py
@@ -29,7 +29,7 @@ class FNCollectionProps(Node, FNBaseNode):
         coll = inputs.get("Collection")
         if coll:
             hide_vp = inputs.get("Hide Viewport")
-            ensure_mutable(coll)
+            coll = ensure_mutable(coll)
             try:
                 coll.hide_viewport = hide_vp
             except Exception:

--- a/nodes/cycles_object_props.py
+++ b/nodes/cycles_object_props.py
@@ -29,7 +29,7 @@ class FNCyclesObjectProps(Node, FNBaseNode):
         obj = inputs.get("Object")
         if obj:
             holdout = inputs.get("Holdout")
-            ensure_mutable(obj)
+            obj = ensure_mutable(obj)
             try:
                 obj.is_holdout = holdout
             except Exception:

--- a/nodes/cycles_scene_props.py
+++ b/nodes/cycles_scene_props.py
@@ -29,7 +29,7 @@ class FNCyclesSceneProps(Node, FNBaseNode):
         scene = inputs.get("Scene")
         if scene and hasattr(scene, "cycles"):
             samples = inputs.get("Samples")
-            ensure_mutable(scene)
+            scene = ensure_mutable(scene)
             try:
                 scene.cycles.samples = samples
             except Exception:

--- a/nodes/eevee_object_props.py
+++ b/nodes/eevee_object_props.py
@@ -29,7 +29,7 @@ class FNEeveeObjectProps(Node, FNBaseNode):
         obj = inputs.get("Object")
         if obj:
             shadow = inputs.get("Visible Shadow")
-            ensure_mutable(obj)
+            obj = ensure_mutable(obj)
             try:
                 obj.visible_shadow = shadow
             except Exception:

--- a/nodes/eevee_scene_props.py
+++ b/nodes/eevee_scene_props.py
@@ -29,7 +29,7 @@ class FNEeveeSceneProps(Node, FNBaseNode):
         scene = inputs.get("Scene")
         if scene and hasattr(scene, "eevee"):
             samples = inputs.get("Samples")
-            ensure_mutable(scene)
+            scene = ensure_mutable(scene)
             try:
                 scene.eevee.taa_render_samples = samples
             except Exception:

--- a/nodes/import_alembic.py
+++ b/nodes/import_alembic.py
@@ -59,7 +59,7 @@ class FNImportAlembic(Node, FNBaseNode):
         for obj in scene.objects:
             if obj not in before:
                 objects.append(obj)
-        ensure_mutable(scene)
+        scene = ensure_mutable(scene)
         _abc_cache[abs_path] = objects
         self._cached_filepath = abs_path
         return {"Objects": objects}

--- a/nodes/light_props.py
+++ b/nodes/light_props.py
@@ -29,7 +29,7 @@ class FNLightProps(Node, FNBaseNode):
         light = inputs.get("Light")
         if light:
             energy = inputs.get("Energy")
-            ensure_mutable(light)
+            light = ensure_mutable(light)
             try:
                 light.energy = energy
             except Exception:

--- a/nodes/link_to_collection.py
+++ b/nodes/link_to_collection.py
@@ -29,7 +29,7 @@ class FNLinkToCollection(Node, FNBaseNode):
         objects = inputs.get("Objects", []) or []
         collections = inputs.get("Collections", []) or []
         if collection:
-            ensure_mutable(collection)
+            collection = ensure_mutable(collection)
             for obj in objects:
                 if not obj:
                     continue

--- a/nodes/link_to_scene.py
+++ b/nodes/link_to_scene.py
@@ -32,7 +32,7 @@ class FNLinkToScene(Node, FNBaseNode):
         collections = inputs.get("Collections", []) or []
         if scene:
             root = scene.collection
-            ensure_mutable(scene)
+            scene = ensure_mutable(scene)
             for obj in objects:
                 if not obj:
                     continue

--- a/nodes/material_props.py
+++ b/nodes/material_props.py
@@ -29,7 +29,7 @@ class FNMaterialProps(Node, FNBaseNode):
         mat = inputs.get("Material")
         if mat:
             use_nodes = inputs.get("Use Nodes")
-            ensure_mutable(mat)
+            mat = ensure_mutable(mat)
             try:
                 mat.use_nodes = use_nodes
             except Exception:

--- a/nodes/mesh_props.py
+++ b/nodes/mesh_props.py
@@ -29,7 +29,7 @@ class FNMeshProps(Node, FNBaseNode):
         mesh = inputs.get("Mesh")
         if mesh:
             auto = inputs.get("Auto Smooth")
-            ensure_mutable(mesh)
+            mesh = ensure_mutable(mesh)
             try:
                 mesh.use_auto_smooth = auto
             except Exception:

--- a/nodes/new_camera.py
+++ b/nodes/new_camera.py
@@ -4,6 +4,7 @@ import bpy
 from bpy.types import Node
 from .base import FNBaseNode, FNCacheIDMixin
 from ..sockets import FNSocketCamera, FNSocketString
+from ..cow_engine import DataProxy
 
 
 class FNNewCamera(Node, FNCacheIDMixin, FNBaseNode):
@@ -27,7 +28,7 @@ class FNNewCamera(Node, FNCacheIDMixin, FNBaseNode):
         name = inputs.get("Name") or "Camera"
         cached = self.cache_get(name)
         if cached is not None:
-            return {"Camera": cached}
+            return {"Camera": DataProxy(cached)}
 
         existing = bpy.data.cameras.get(name)
         if existing is not None:
@@ -35,11 +36,11 @@ class FNNewCamera(Node, FNCacheIDMixin, FNBaseNode):
 
         if cached is not None:
             self.cache_store(name, cached)
-            return {"Camera": cached}
+            return {"Camera": DataProxy(cached)}
 
         cam = bpy.data.cameras.new(name)
         self.cache_store(name, cam)
-        return {"Camera": cam}
+        return {"Camera": DataProxy(cam)}
 
 
 def register():

--- a/nodes/new_collection.py
+++ b/nodes/new_collection.py
@@ -4,6 +4,7 @@ import bpy
 from bpy.types import Node
 from .base import FNBaseNode, FNCacheIDMixin
 from ..sockets import FNSocketCollection, FNSocketString
+from ..cow_engine import DataProxy
 
 
 class FNNewCollection(Node, FNCacheIDMixin, FNBaseNode):
@@ -27,7 +28,7 @@ class FNNewCollection(Node, FNCacheIDMixin, FNBaseNode):
         name = inputs.get("Name") or "Collection"
         cached = self.cache_get(name)
         if cached is not None:
-            return {"Collection": cached}
+            return {"Collection": DataProxy(cached)}
 
         existing = bpy.data.collections.get(name)
         if existing is not None:
@@ -35,11 +36,11 @@ class FNNewCollection(Node, FNCacheIDMixin, FNBaseNode):
 
         if cached is not None:
             self.cache_store(name, cached)
-            return {"Collection": cached}
+            return {"Collection": DataProxy(cached)}
 
         coll = bpy.data.collections.new(name)
         self.cache_store(name, coll)
-        return {"Collection": coll}
+        return {"Collection": DataProxy(coll)}
 
 
 def register():

--- a/nodes/new_light.py
+++ b/nodes/new_light.py
@@ -4,6 +4,7 @@ import bpy
 from bpy.types import Node
 from .base import FNBaseNode, FNCacheIDMixin
 from ..sockets import FNSocketLight, FNSocketString
+from ..cow_engine import DataProxy
 
 
 class FNNewLight(Node, FNCacheIDMixin, FNBaseNode):
@@ -43,7 +44,7 @@ class FNNewLight(Node, FNCacheIDMixin, FNBaseNode):
         key = (name, self.light_type)
         cached = self.cache_get(key)
         if cached is not None:
-            return {"Light": cached}
+            return {"Light": DataProxy(cached)}
 
         existing = bpy.data.lights.get(name)
         if existing is not None:
@@ -51,11 +52,11 @@ class FNNewLight(Node, FNCacheIDMixin, FNBaseNode):
 
         if cached is not None:
             self.cache_store(key, cached)
-            return {"Light": cached}
+            return {"Light": DataProxy(cached)}
 
         light = bpy.data.lights.new(name, type=self.light_type)
         self.cache_store(key, light)
-        return {"Light": light}
+        return {"Light": DataProxy(light)}
 
 
 def register():

--- a/nodes/new_material.py
+++ b/nodes/new_material.py
@@ -4,6 +4,7 @@ import bpy
 from bpy.types import Node
 from .base import FNBaseNode, FNCacheIDMixin
 from ..sockets import FNSocketMaterial, FNSocketString
+from ..cow_engine import DataProxy
 
 
 class FNNewMaterial(Node, FNCacheIDMixin, FNBaseNode):
@@ -27,7 +28,7 @@ class FNNewMaterial(Node, FNCacheIDMixin, FNBaseNode):
         name = inputs.get("Name") or "Material"
         cached = self.cache_get(name)
         if cached is not None:
-            return {"Material": cached}
+            return {"Material": DataProxy(cached)}
 
         existing = bpy.data.materials.get(name)
         if existing is not None:
@@ -35,11 +36,11 @@ class FNNewMaterial(Node, FNCacheIDMixin, FNBaseNode):
 
         if cached is not None:
             self.cache_store(name, cached)
-            return {"Material": cached}
+            return {"Material": DataProxy(cached)}
 
         mat = bpy.data.materials.new(name)
         self.cache_store(name, mat)
-        return {"Material": mat}
+        return {"Material": DataProxy(mat)}
 
 
 def register():

--- a/nodes/new_mesh.py
+++ b/nodes/new_mesh.py
@@ -4,6 +4,7 @@ import bpy
 from bpy.types import Node
 from .base import FNBaseNode, FNCacheIDMixin
 from ..sockets import FNSocketMesh, FNSocketString
+from ..cow_engine import DataProxy
 
 
 class FNNewMesh(Node, FNCacheIDMixin, FNBaseNode):
@@ -27,7 +28,7 @@ class FNNewMesh(Node, FNCacheIDMixin, FNBaseNode):
         name = inputs.get("Name") or "Mesh"
         cached = self.cache_get(name)
         if cached is not None:
-            return {"Mesh": cached}
+            return {"Mesh": DataProxy(cached)}
 
         existing = bpy.data.meshes.get(name)
         if existing is not None:
@@ -35,11 +36,11 @@ class FNNewMesh(Node, FNCacheIDMixin, FNBaseNode):
 
         if cached is not None:
             self.cache_store(name, cached)
-            return {"Mesh": cached}
+            return {"Mesh": DataProxy(cached)}
 
         mesh = bpy.data.meshes.new(name)
         self.cache_store(name, mesh)
-        return {"Mesh": mesh}
+        return {"Mesh": DataProxy(mesh)}
 
 
 def register():

--- a/nodes/new_object.py
+++ b/nodes/new_object.py
@@ -6,6 +6,7 @@ from .base import FNBaseNode, FNCacheIDMixin
 from ..sockets import (
     FNSocketObject, FNSocketMesh, FNSocketLight, FNSocketCamera, FNSocketString
 )
+from ..cow_engine import DataProxy
 from ..operators import auto_evaluate_if_enabled
 
 _object_data_socket = {
@@ -87,7 +88,7 @@ class FNNewObject(Node, FNCacheIDMixin, FNBaseNode):
         else:
             obj = bpy.data.objects.new(name, data)
         self.cache_store(key, obj)
-        return {"Object": obj}
+        return {"Object": DataProxy(obj)}
 
 
 def register():

--- a/nodes/new_scene.py
+++ b/nodes/new_scene.py
@@ -4,6 +4,7 @@ import bpy
 from bpy.types import Node
 from .base import FNBaseNode, FNCacheIDMixin
 from ..sockets import FNSocketScene, FNSocketString
+from ..cow_engine import DataProxy
 
 
 class FNNewScene(Node, FNCacheIDMixin, FNBaseNode):
@@ -27,7 +28,7 @@ class FNNewScene(Node, FNCacheIDMixin, FNBaseNode):
         name = inputs.get("Name") or "Scene"
         cached = self.cache_get(name)
         if cached is not None:
-            return {"Scene": cached}
+            return {"Scene": DataProxy(cached)}
 
         existing = bpy.data.scenes.get(name)
         if existing is not None:
@@ -35,12 +36,12 @@ class FNNewScene(Node, FNCacheIDMixin, FNBaseNode):
 
         if cached is not None:
             self.cache_store(name, cached)
-            return {"Scene": cached}
+            return {"Scene": DataProxy(cached)}
 
         scene = bpy.data.scenes.new(name)
         scene.use_extra_user = True
         self.cache_store(name, scene)
-        return {"Scene": scene}
+        return {"Scene": DataProxy(scene)}
 
 
 def register():

--- a/nodes/new_text.py
+++ b/nodes/new_text.py
@@ -4,6 +4,7 @@ import bpy
 from bpy.types import Node
 from .base import FNBaseNode, FNCacheIDMixin
 from ..sockets import FNSocketText, FNSocketString
+from ..cow_engine import DataProxy
 
 
 class FNNewText(Node, FNCacheIDMixin, FNBaseNode):
@@ -27,7 +28,7 @@ class FNNewText(Node, FNCacheIDMixin, FNBaseNode):
         name = inputs.get("Name") or "Text"
         cached = self.cache_get(name)
         if cached is not None:
-            return {"Text": cached}
+            return {"Text": DataProxy(cached)}
 
         existing = bpy.data.texts.get(name)
         if existing is not None:
@@ -35,11 +36,11 @@ class FNNewText(Node, FNCacheIDMixin, FNBaseNode):
 
         if cached is not None:
             self.cache_store(name, cached)
-            return {"Text": cached}
+            return {"Text": DataProxy(cached)}
 
         text = bpy.data.texts.new(name)
         self.cache_store(name, text)
-        return {"Text": text}
+        return {"Text": DataProxy(text)}
 
 
 def register():

--- a/nodes/new_viewlayer.py
+++ b/nodes/new_viewlayer.py
@@ -4,6 +4,7 @@ import bpy
 from bpy.types import Node
 from .base import FNBaseNode, FNCacheIDMixin
 from ..sockets import FNSocketScene, FNSocketString, FNSocketViewLayer
+from ..cow_engine import DataProxy
 
 
 class FNNewViewLayer(Node, FNCacheIDMixin, FNBaseNode):
@@ -32,7 +33,7 @@ class FNNewViewLayer(Node, FNCacheIDMixin, FNBaseNode):
         key = (scene.as_pointer(), name)
         cached = self.cache_get(key)
         if cached is not None:
-            return {"ViewLayer": cached}
+            return {"ViewLayer": DataProxy(cached)}
 
         existing = scene.view_layers.get(name)
         if existing is not None:
@@ -40,11 +41,11 @@ class FNNewViewLayer(Node, FNCacheIDMixin, FNBaseNode):
 
         if cached is not None:
             self.cache_store(key, cached)
-            return {"ViewLayer": cached}
+            return {"ViewLayer": DataProxy(cached)}
 
         view_layer = scene.view_layers.new(name)
         self.cache_store(key, view_layer)
-        return {"ViewLayer": view_layer}
+        return {"ViewLayer": DataProxy(view_layer)}
 
 
 def register():

--- a/nodes/new_world.py
+++ b/nodes/new_world.py
@@ -4,6 +4,7 @@ import bpy
 from bpy.types import Node
 from .base import FNBaseNode, FNCacheIDMixin
 from ..sockets import FNSocketWorld, FNSocketString
+from ..cow_engine import DataProxy
 
 
 class FNNewWorld(Node, FNCacheIDMixin, FNBaseNode):
@@ -27,7 +28,7 @@ class FNNewWorld(Node, FNCacheIDMixin, FNBaseNode):
         name = inputs.get("Name") or "World"
         cached = self.cache_get(name)
         if cached is not None:
-            return {"World": cached}
+            return {"World": DataProxy(cached)}
 
         existing = bpy.data.worlds.get(name)
         if existing is not None:
@@ -35,11 +36,11 @@ class FNNewWorld(Node, FNCacheIDMixin, FNBaseNode):
 
         if cached is not None:
             self.cache_store(name, cached)
-            return {"World": cached}
+            return {"World": DataProxy(cached)}
 
         world = bpy.data.worlds.new(name)
         self.cache_store(name, world)
-        return {"World": world}
+        return {"World": DataProxy(world)}
 
 
 def register():

--- a/nodes/object_props.py
+++ b/nodes/object_props.py
@@ -32,7 +32,7 @@ class FNObjectProps(Node, FNBaseNode):
         if obj:
             hide_vp = inputs.get("Hide Viewport")
             hide_re = inputs.get("Hide Render")
-            ensure_mutable(obj)
+            obj = ensure_mutable(obj)
             try:
                 obj.hide_viewport = hide_vp
                 obj.hide_render = hide_re

--- a/nodes/output_props.py
+++ b/nodes/output_props.py
@@ -32,7 +32,7 @@ class FNOutputProps(Node, FNBaseNode):
         if scene:
             res_x = inputs.get("Resolution X")
             res_y = inputs.get("Resolution Y")
-            ensure_mutable(scene)
+            scene = ensure_mutable(scene)
             try:
                 scene.render.resolution_x = res_x
                 scene.render.resolution_y = res_y

--- a/nodes/scene_props.py
+++ b/nodes/scene_props.py
@@ -32,7 +32,7 @@ class FNSceneProps(Node, FNBaseNode):
         if scene:
             start = inputs.get("Start")
             end = inputs.get("End")
-            ensure_mutable(scene)
+            scene = ensure_mutable(scene)
             try:
                 scene.frame_start = start
                 scene.frame_end = end

--- a/nodes/set_collection_name.py
+++ b/nodes/set_collection_name.py
@@ -27,7 +27,7 @@ class FNSetCollectionName(Node, FNBaseNode):
         coll = inputs.get("Collection")
         if coll:
             name = inputs.get("Name") or ""
-            ensure_mutable(coll)
+            coll = ensure_mutable(coll)
             try:
                 coll.name = name
             except Exception:

--- a/nodes/set_object_name.py
+++ b/nodes/set_object_name.py
@@ -27,7 +27,7 @@ class FNSetObjectName(Node, FNBaseNode):
         obj = inputs.get("Object")
         if obj:
             name = inputs.get("Name") or ""
-            ensure_mutable(obj)
+            obj = ensure_mutable(obj)
             try:
                 obj.name = name
             except Exception:

--- a/nodes/set_render_engine.py
+++ b/nodes/set_render_engine.py
@@ -29,7 +29,7 @@ class FNSetRenderEngine(Node, FNBaseNode):
         scene = inputs.get("Scene")
         if scene:
             engine = inputs.get("Engine")
-            ensure_mutable(scene)
+            scene = ensure_mutable(scene)
             try:
                 scene.render.engine = engine
             except Exception:

--- a/nodes/set_scene_name.py
+++ b/nodes/set_scene_name.py
@@ -27,7 +27,7 @@ class FNSetSceneName(Node, FNBaseNode):
         scene = inputs.get("Scene")
         if scene:
             name = inputs.get("Name") or ""
-            ensure_mutable(scene)
+            scene = ensure_mutable(scene)
             try:
                 scene.name = name
             except Exception:

--- a/nodes/set_scene_viewlayers.py
+++ b/nodes/set_scene_viewlayers.py
@@ -5,6 +5,7 @@ from bpy.types import Node
 
 from .base import FNBaseNode
 from ..sockets import FNSocketScene, FNSocketViewLayerList
+from ..cow_engine import ensure_mutable
 
 
 class FNSetSceneViewlayers(Node, FNBaseNode):
@@ -28,6 +29,7 @@ class FNSetSceneViewlayers(Node, FNBaseNode):
         layers = [vl for vl in (inputs.get("ViewLayers") or []) if vl]
         if not scene:
             return {"Scene": scene}
+        scene = ensure_mutable(scene)
 
         def _warn(msg):
             report = getattr(self, "report", None)

--- a/nodes/set_world.py
+++ b/nodes/set_world.py
@@ -24,7 +24,7 @@ class FNSetWorld(Node, FNBaseNode):
         scene = inputs.get("Scene")
         world = inputs.get("World")
         if scene and world:
-            ensure_mutable(scene)
+            scene = ensure_mutable(scene)
             scene.world = world
         return {"Scene": scene}
 

--- a/nodes/viewlayer_visibility.py
+++ b/nodes/viewlayer_visibility.py
@@ -213,7 +213,7 @@ class FNViewLayerVisibility(Node, FNBaseNode):
                 layer = _find_layer_collection(view_layer.layer_collection, coll)
                 if not layer:
                     continue
-                ensure_mutable(layer)
+                layer = ensure_mutable(layer)
                 try:
                     layer.exclude = item.exclude
                 except Exception:

--- a/nodes/workbench_scene_props.py
+++ b/nodes/workbench_scene_props.py
@@ -29,7 +29,7 @@ class FNWorkbenchSceneProps(Node, FNBaseNode):
         scene = inputs.get("Scene")
         if scene and hasattr(scene, "display"):
             samples = inputs.get("AA Samples")
-            ensure_mutable(scene)
+            scene = ensure_mutable(scene)
             try:
                 if hasattr(scene.display, 'render_aa'):
                     scene.display.render_aa = samples

--- a/nodes/world_props.py
+++ b/nodes/world_props.py
@@ -29,7 +29,7 @@ class FNWorldProps(Node, FNBaseNode):
         world = inputs.get("World")
         if world:
             use_nodes = inputs.get("Use Nodes")
-            ensure_mutable(world)
+            world = ensure_mutable(world)
             try:
                 world.use_nodes = use_nodes
             except Exception:

--- a/tests/test_new_object.py
+++ b/tests/test_new_object.py
@@ -94,6 +94,13 @@ for cls in ["FNSocketObject", "FNSocketMesh", "FNSocketLight", "FNSocketCamera",
     setattr(sockets_mod, cls, type(cls, (), {}))
 sys.modules["addon.sockets"] = sockets_mod
 
+# cow_engine stub
+spec_cow = importlib.util.spec_from_file_location("addon.cow_engine", os.path.join(ROOT, "cow_engine.py"))
+cow_mod = importlib.util.module_from_spec(spec_cow)
+cow_mod.bpy = bpy
+spec_cow.loader.exec_module(cow_mod)
+sys.modules["addon.cow_engine"] = cow_mod
+
 # ---- load new_object module ----
 spec = importlib.util.spec_from_file_location("addon.nodes.new_object", os.path.join(ROOT, "nodes", "new_object.py"))
 new_object = importlib.util.module_from_spec(spec)
@@ -113,10 +120,11 @@ def test_existing_object_updates_data():
 
     mesh_b = bpy.data.meshes.new('MeshB')
     out = node.process(None, {'Name': 'Obj', 'Data': mesh_b})
-    assert out['Object'] is obj
+    assert isinstance(out['Object'], cow_mod.DataProxy)
+    assert out['Object'].data is obj
     assert obj.data is mesh_b
 
     mesh_c = bpy.data.meshes.new('MeshC')
     out2 = node.process(None, {'Name': 'Obj', 'Data': mesh_c})
-    assert out2['Object'] is obj
+    assert out2['Object'].data is obj
     assert obj.data is mesh_c


### PR DESCRIPTION
## Summary
- ensure mutable copy is taken before editing datablocks
- output `DataProxy` wrappers from creation nodes
- update tests for wrapped outputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ee07279c8330aec6a386ffa6bae5