### PR TITLE
Fix DataProxy __setattr__ for data assignment

### DIFF
--- a/cow_engine.py
+++ b/cow_engine.py
@@ -25,6 +25,8 @@ class DataProxy:
     def __setattr__(self, name, value):
         if name in {"_data", "refcount"}:
             object.__setattr__(self, name, value)
+        elif name == "data":
+            object.__setattr__(self, "_data", value)
         else:
             ensure_mutable(self)
             setattr(self._data, name, value)


### PR DESCRIPTION
## Summary
- correctly assign to DataProxy `_data` when setting `.data`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862fdb78968833081943547d6d88b5e