### PR TITLE
Add Execute Input node with execution operator

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -23,6 +23,7 @@ categories = [
         NodeItem('FNSwitch'),
         NodeItem('FNIndexSwitch'),
         NodeItem('FNSetCustomProperty'),
+        NodeItem('FNExecLogic'),
     ]),
     NodeCategory('FILE_NODES_SCENE', 'Scene', items=[
         NodeItem('FNSceneInputNode'),
@@ -101,6 +102,7 @@ categories = [
     ]),
     NodeCategory('FILE_NODES_VALUES', 'Values', items=[
         NodeItem('FNBoolInputNode'),
+        NodeItem('FNExecInputNode'),
         NodeItem('FNFloatInputNode'),
         NodeItem('FNIntInputNode'),
         NodeItem('FNStringInputNode'),

--- a/nodes/input_nodes.py
+++ b/nodes/input_nodes.py
@@ -6,7 +6,7 @@ from ..operators import auto_evaluate_if_enabled
 
 from .base import FNBaseNode, FNCacheIDMixin
 from ..sockets import (
-    FNSocketBool, FNSocketFloat, FNSocketVector, FNSocketInt, FNSocketString,
+    FNSocketBool, FNSocketExec, FNSocketFloat, FNSocketVector, FNSocketInt, FNSocketString,
     FNSocketScene, FNSocketObject, FNSocketCollection, FNSocketWorld,
     FNSocketCamera, FNSocketImage, FNSocketLight, FNSocketMaterial,
     FNSocketMesh, FNSocketNodeTree, FNSocketText, FNSocketWorkSpace,
@@ -28,6 +28,25 @@ class FNBoolInputNode(Node, FNBaseNode):
 
     def process(self, context, inputs, manager):
         return {"Boolean": self.value}
+
+
+class FNExecInputNode(Node, FNBaseNode):
+    """Output an execution trigger."""
+    bl_idname = "FNExecInputNode"
+    bl_label = "Execute Input"
+
+    value: bpy.props.BoolProperty(name="Value", update=auto_evaluate_if_enabled)
+
+    def init(self, context):
+        self.outputs.new('FNSocketExec', 'Exec')
+
+    def draw_buttons(self, context, layout):
+        row = layout.row(align=True)
+        row.prop(self, 'value', text='')
+        row.operator('file_nodes.execute_input', text='Execute')
+
+    def process(self, context, inputs, manager):
+        return {'Exec': self.value}
 
 
 class FNFloatInputNode(Node, FNBaseNode):
@@ -89,7 +108,7 @@ from ..operators import auto_evaluate_if_enabled
 
 from .base import FNBaseNode, FNCacheIDMixin
 from ..sockets import (
-    FNSocketBool, FNSocketFloat, FNSocketVector, FNSocketInt, FNSocketString,
+    FNSocketBool, FNSocketExec, FNSocketFloat, FNSocketVector, FNSocketInt, FNSocketString,
     FNSocketScene, FNSocketObject, FNSocketCollection, FNSocketWorld,
     FNSocketCamera, FNSocketImage, FNSocketLight, FNSocketMaterial,
     FNSocketMesh, FNSocketNodeTree, FNSocketText, FNSocketWorkSpace,
@@ -422,7 +441,7 @@ class FNWorkSpaceInputNode(Node, FNBaseNode):
 
 
 _classes = (
-    FNBoolInputNode, FNFloatInputNode, FNIntInputNode, FNStringInputNode,
+    FNBoolInputNode, FNExecInputNode, FNFloatInputNode, FNIntInputNode, FNStringInputNode,
     FNVectorInputNode, FNColorInputNode,
     FNSceneInputNode, FNObjectInputNode, FNCollectionInputNode,
     FNWorldInputNode, FNCameraInputNode, FNImageInputNode, FNLightInputNode, FNMaterialInputNode,

--- a/operators.py
+++ b/operators.py
@@ -134,6 +134,25 @@ class FN_OT_render_scenes(Operator):
         return {"FINISHED"}
 
 
+class FN_OT_execute_input(Operator):
+    bl_idname = "file_nodes.execute_input"
+    bl_label = "Execute"
+
+    def execute(self, context):
+        node = context.active_node
+        if (
+            not isinstance(node, bpy.types.Node)
+            or node.bl_idname != "FNExecInputNode"
+        ):
+            return {"CANCELLED"}
+
+        node.outputs.get("Exec").value = True
+        evaluate_tree(context)
+        node.outputs.get("Exec").value = False
+
+        return {"FINISHED"}
+
+
 def auto_evaluate_if_enabled(self=None, context=None):
     """Evaluate all file node trees if the preference is enabled."""
     if context is None and isinstance(self, bpy.types.Context):
@@ -198,6 +217,7 @@ def register():
     bpy.utils.register_class(FN_OT_ungroup_nodes)
     bpy.utils.register_class(FN_OT_trigger_exec)
     bpy.utils.register_class(FN_OT_render_scenes)
+    bpy.utils.register_class(FN_OT_execute_input)
     bpy.utils.register_class(FN_OT_new_tree)
     bpy.utils.register_class(FN_OT_remove_tree)
 
@@ -206,6 +226,7 @@ def unregister():
     bpy.utils.unregister_class(FN_OT_remove_tree)
     bpy.utils.unregister_class(FN_OT_new_tree)
     bpy.utils.unregister_class(FN_OT_render_scenes)
+    bpy.utils.unregister_class(FN_OT_execute_input)
     bpy.utils.unregister_class(FN_OT_trigger_exec)
     bpy.utils.unregister_class(FN_OT_ungroup_nodes)
     bpy.utils.unregister_class(FN_OT_group_nodes)


### PR DESCRIPTION
## Summary
- add Execute Input node for triggering execution via an output Exec socket
- expose Execute Input and Exec Logic nodes in the add menu
- add execute_input operator and register it

## Testing
- `pytest -q` *(fails: module 'addon.cow_engine' has no attribute 'DataProxy')*

------
https://chatgpt.com/codex/tasks/task_e_686554e1fea88330ab05eabf01392233